### PR TITLE
Communicate profile/location over mesh

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -660,6 +660,22 @@ ELSE()
 			COMMENT "View documentation"
 			DEPENDS generate_documentation
 			)
+
+		ADD_CUSTOM_TARGET(erase
+			COMMAND ${CMAKE_COMMAND} -E echo
+			COMMAND ${CMAKE_COMMAND} -E echo "** Use nrfjprog to erase target board"
+			COMMAND ${CMAKE_COMMAND} -E echo
+			COMMAND nrfjprog -f nrf52 --eraseall ${SERIAL_NUM_SWITCH} ${SERIAL_NUM}
+			COMMENT "Erase everything on target board"
+			)
+
+		ADD_CUSTOM_TARGET(reset
+			COMMAND ${CMAKE_COMMAND} -E echo
+			COMMAND ${CMAKE_COMMAND} -E echo "** Use nrfjprog to reset target board"
+			COMMAND ${CMAKE_COMMAND} -E echo
+			COMMAND nrfjprog -f nrf52 --reset ${SERIAL_NUM_SWITCH} ${SERIAL_NUM}
+			COMMENT "Reset target board"
+			)
 			
 		# Create a new version, create new release directory
 		# Copy CMakeBuild.config.relesae.default.release to this directory

--- a/source/conf/cmake/CMakeBuild.config.default
+++ b/source/conf/cmake/CMakeBuild.config.default
@@ -43,6 +43,9 @@ CHANGE_NAME_ON_RESET=0
 MESHING=1
 BUILD_MESHING=1
 
+# Use the (active) scanner in the mesh
+MESH_SCANNER=1
+
 # Advertise iBeacon packets.
 IBEACON=1
 

--- a/source/conf/cmake/crownstone.defs.cmake
+++ b/source/conf/cmake/crownstone.defs.cmake
@@ -147,6 +147,8 @@ ADD_DEFINITIONS("-DCHAR_STATE=${CHAR_STATE}")
 
 # Publish all options as CMake options as well
 
+ADD_DEFINITIONS("-DMESH_SCANNER=${MESH_SCANNER}")
+
 # Obtain variables to be used for the compiler
 SET(NRF5_DIR                                    "${NRF5_DIR}"                   CACHE STRING "Nordic SDK Directory" FORCE)
 SET(NORDIC_SDK_VERSION                          "${NORDIC_SDK_VERSION}"             CACHE STRING "Nordic SDK Version" FORCE)

--- a/source/include/common/cs_Types.h
+++ b/source/include/common/cs_Types.h
@@ -237,6 +237,8 @@ enum class CS_TYPE: uint16_t {
 	CMD_SET_RELAY,								// when a user requests to set the relay to a specific state
 	CMD_SET_DIMMER,								// when a user requests to set the dimmer to a specific state
 	// ------------------------
+	//
+	EVT_PROFILE_LOCATION,                       // profile and location information 
 };
 
 CS_TYPE toCsType(uint16_t type);
@@ -406,6 +408,7 @@ typedef uint8_t TYPIFY(EVT_BEHAVIOUR_SWITCH_STATE);
 typedef void TYPIFY(EVT_PRESENCE_MUTATION);
 typedef bool TYPIFY(CMD_SET_RELAY);
 typedef uint8_t TYPIFY(CMD_SET_DIMMER); // interpret as intensity value, not combined with relay state.
+typedef cs_mesh_model_msg_profile_location_t TYPIFY(EVT_PROFILE_LOCATION);
 
 /*---------------------------------------------------------------------------------------------------------------------
  *

--- a/source/include/mesh/cs_MeshModel.h
+++ b/source/include/mesh/cs_MeshModel.h
@@ -65,6 +65,8 @@ public:
 	cs_ret_code_t sendMultiSwitchItem(const internal_multi_switch_item_t* item, uint8_t repeats=10);
 	cs_ret_code_t sendKeepAliveItem(const keep_alive_state_item_t* item, uint8_t repeats=5);
 	cs_ret_code_t sendTime(const cs_mesh_model_msg_time_t* item, uint8_t repeats=1);
+	
+	cs_ret_code_t sendProfileLocation(const cs_mesh_model_msg_profile_location_t* item, uint8_t repeats=1);
 
 	access_model_handle_t getAccessModelHandle();
 

--- a/source/include/presence/cs_PresenceHandler.h
+++ b/source/include/presence/cs_PresenceHandler.h
@@ -18,8 +18,8 @@
  * find out which users are in which room. It can be queried
  * by other 
  */
-class PresenceHandler: public EventListener{
-    private:
+class PresenceHandler: public EventListener {
+private:
     // after this amount of seconds a presence_record becomes invalid.
     static const constexpr uint32_t presence_time_out_s = 5*60;
 
@@ -44,8 +44,14 @@ class PresenceHandler: public EventListener{
 
     void removeOldRecords();
     void print();
+    
+    stone_id_t _ownId = 0;
 
-    public:
+public:
+
+    // register as event handler
+    void init();
+
     // receive background messages indicating where users are,
     // record the time and place and update the current presence description
     // when necessary

--- a/source/include/processing/cs_MultiSwitchHandler.h
+++ b/source/include/processing/cs_MultiSwitchHandler.h
@@ -10,7 +10,7 @@
 #include "events/cs_EventListener.h"
 #include "common/cs_Types.h"
 
-class MultiSwitchHandler : EventListener {
+class MultiSwitchHandler : public EventListener {
 private:
 	MultiSwitchHandler();
 public:

--- a/source/include/protocol/mesh/cs_MeshModelPacketHelper.h
+++ b/source/include/protocol/mesh/cs_MeshModelPacketHelper.h
@@ -24,6 +24,7 @@ bool keepAliveStateIsValid(const cs_mesh_model_msg_keep_alive_t* packet, size16_
 bool keepAliveIsValid(const uint8_t* packet, size16_t size);
 bool state0IsValid(const cs_mesh_model_msg_state_0_t* packet, size16_t size);
 bool state1IsValid(const cs_mesh_model_msg_state_1_t* packet, size16_t size);
+bool profileLocationIsValid(const cs_mesh_model_msg_profile_location_t* packet, size16_t size);
 
 cs_mesh_model_msg_type_t getType(const uint8_t* meshMsg);
 

--- a/source/include/protocol/mesh/cs_MeshModelPackets.h
+++ b/source/include/protocol/mesh/cs_MeshModelPackets.h
@@ -50,6 +50,7 @@ enum cs_mesh_model_msg_type_t {
 	CS_MESH_MODEL_TYPE_CMD_KEEP_ALIVE = 7,       // Payload: none
 	CS_MESH_MODEL_TYPE_STATE_0 = 8,              // Payload: cs_mesh_model_msg_state_0_t
 	CS_MESH_MODEL_TYPE_STATE_1 = 9,              // Payload: cs_mesh_model_msg_state_1_t
+	CS_MESH_MODEL_TYPE_PROFILE_LOCATION = 10,    // Payload: cs_mesh_model_msg_profile_location_t
 };
 
 struct __attribute__((__packed__)) cs_mesh_model_msg_test_t {
@@ -63,6 +64,11 @@ struct __attribute__((__packed__)) cs_mesh_model_msg_time_t {
 	uint32_t timestamp;
 };
 
+struct __attribute__((__packed__)) cs_mesh_model_msg_profile_location_t {
+	uint8_t profile;
+	uint8_t location;
+	stone_id_t stone_id;
+};
 
 struct __attribute__((__packed__)) cs_mesh_model_msg_state_0_t {
 	uint8_t switchState;

--- a/source/src/common/cs_Types.cpp
+++ b/source/src/common/cs_Types.cpp
@@ -149,6 +149,7 @@ CS_TYPE toCsType(uint16_t type) {
 	case CS_TYPE::EVT_BEHAVIOUR_SWITCH_STATE:
 	case CS_TYPE::CMD_SET_RELAY:
 	case CS_TYPE::CMD_SET_DIMMER:
+	case CS_TYPE::EVT_PROFILE_LOCATION:
 		return csType;
 	}
 	return CS_TYPE::CONFIG_DO_NOT_USE;
@@ -441,6 +442,8 @@ size16_t TypeSize(CS_TYPE const & type){
 		return sizeof(TYPIFY(CMD_SET_RELAY));
 	case CS_TYPE::CMD_SET_DIMMER:
 		return sizeof(TYPIFY(CMD_SET_DIMMER));	
+	case CS_TYPE::EVT_PROFILE_LOCATION:
+		return sizeof(TYPIFY(EVT_PROFILE_LOCATION));	
 	} // end switch
 
 	// should never happen
@@ -587,6 +590,7 @@ const char* TypeName(CS_TYPE const & type) {
 	case CS_TYPE::EVT_BEHAVIOUR_SWITCH_STATE: return "EVT_BEHAVIOUR_SWITCH_STATE";
 	case CS_TYPE::CMD_SET_RELAY: return "CMD_SET_RELAY";
 	case CS_TYPE::CMD_SET_DIMMER: return "CMD_SET_DIMMER";
+	case CS_TYPE::EVT_PROFILE_LOCATION: return "EVT_PROFILE_LOCATION";
 	}
 	return "Unknown";
 }
@@ -734,6 +738,7 @@ cs_file_id_t getFileId(CS_TYPE const & type){
 	case CS_TYPE::EVT_BEHAVIOUR_SWITCH_STATE:
 	case CS_TYPE::CMD_SET_RELAY:
 	case CS_TYPE::CMD_SET_DIMMER:
+	case CS_TYPE::EVT_PROFILE_LOCATION:
 		return FILE_DO_NOT_USE;
 	}
 	// should not reach this
@@ -881,6 +886,7 @@ EncryptionAccessLevel getUserAccessLevelSet(CS_TYPE const & type)  {
 	case CS_TYPE::EVT_BEHAVIOUR_SWITCH_STATE:
 	case CS_TYPE::CMD_SET_RELAY:
 	case CS_TYPE::CMD_SET_DIMMER:
+	case CS_TYPE::EVT_PROFILE_LOCATION:
 		return NO_ONE;
 	}
 	return NO_ONE;
@@ -1027,6 +1033,7 @@ EncryptionAccessLevel getUserAccessLevelGet(CS_TYPE const & type) {
 	case CS_TYPE::EVT_BEHAVIOUR_SWITCH_STATE:
 	case CS_TYPE::CMD_SET_RELAY:
 	case CS_TYPE::CMD_SET_DIMMER:
+	case CS_TYPE::EVT_PROFILE_LOCATION:
 		return NO_ONE;
 	}
 	return NO_ONE;

--- a/source/src/cs_Crownstone.cpp
+++ b/source/src/cs_Crownstone.cpp
@@ -583,6 +583,7 @@ void Crownstone::setName() {
 void Crownstone::startOperationMode(const OperationMode & mode) {
 	EventDispatcher::getInstance().addListener(&_behaviourHandler);
 	EventDispatcher::getInstance().addListener(&_behaviourStore);
+	_presenceHandler.init();
 	EventDispatcher::getInstance().addListener(&_presenceHandler);
 	
 	switch(mode) {

--- a/source/src/cs_Crownstone.cpp
+++ b/source/src/cs_Crownstone.cpp
@@ -980,9 +980,9 @@ void initUart(uint8_t pinRx, uint8_t pinTx) {
 	serial_init(SERIAL_ENABLE_RX_AND_TX);
 	_log(SERIAL_INFO, SERIAL_CRLF);
 
-#ifdef GIT_HASH
+#ifdef GIT_SHA1
 #undef FIRMWARE_VERSION
-#define FIRMWARE_VERSION GIT_HASH
+#define FIRMWARE_VERSION GIT_SHA1
 #endif
 
 	LOGi("Welcome! Bluenet firmware, version %s", g_GIT_SHA1);

--- a/source/src/mesh/cs_Mesh.cpp
+++ b/source/src/mesh/cs_Mesh.cpp
@@ -160,6 +160,8 @@ static void config_server_evt_cb(const config_server_evt_t * p_evt) {
 static uint8_t start_address[3];
 #endif
 
+#if MESH_SCANNER == 1
+
 /**
  * Variable to copy scanned data to, so that it doesn't get created on the stack all the time.
  * Made static, since the callback isn't part of the class.
@@ -231,10 +233,7 @@ static void scan_cb(const nrf_mesh_adv_packet_rx_data_t *p_rx_data) {
 	}
 }
 
-
-
-
-
+#endif
 
 void Mesh::modelsInitCallback() {
 	LOGi("Initializing and adding models");
@@ -285,9 +284,14 @@ void Mesh::init(const boards_config_t& board) {
 	LOGi("Scan interval=%ums window=%ums", board.scanIntervalUs/1000, board.scanWindowUs/1000);
 	scanner_config_scan_time_set(board.scanIntervalUs, board.scanWindowUs);
 
+#if MESH_SCANNER == 1
 	// Init scanned device variable before registering the callback.
+	LOGi("Scanner in mesh enabled");
 	memset(&_scannedDevice, 0, sizeof(_scannedDevice));
 	nrf_mesh_rx_cb_set(scan_cb);
+#else
+	LOGw("Scanner in mesh not enabled");
+#endif
 
 	ble_gap_addr_t macAddress;
 	retCode = sd_ble_gap_addr_get(&macAddress);

--- a/source/src/mesh/cs_Mesh.cpp
+++ b/source/src/mesh/cs_Mesh.cpp
@@ -555,6 +555,11 @@ void Mesh::handleEvent(event_t & event) {
 		factoryReset();
 		break;
 	}
+	case CS_TYPE::EVT_PROFILE_LOCATION: {
+		TYPIFY(EVT_PROFILE_LOCATION)* packet = (TYPIFY(EVT_PROFILE_LOCATION)*)event.data;
+		_model.sendProfileLocation(packet);
+		break;
+	}
 	default:
 		break;
 	}

--- a/source/src/mesh/cs_MeshModel.cpp
+++ b/source/src/mesh/cs_MeshModel.cpp
@@ -116,12 +116,20 @@ cs_ret_code_t MeshModel::sendTime(const cs_mesh_model_msg_time_t* item, uint8_t 
 	return addToQueue(CS_MESH_MODEL_TYPE_STATE_TIME, 0, (uint8_t*)item, sizeof(*item), repeats, false);
 }
 
+cs_ret_code_t MeshModel::sendProfileLocation(const cs_mesh_model_msg_profile_location_t* item, uint8_t repeats) {
+	remFromQueue(CS_MESH_MODEL_TYPE_PROFILE_LOCATION, 0);
+	return addToQueue(CS_MESH_MODEL_TYPE_PROFILE_LOCATION, 0, (uint8_t*)item, sizeof(*item), repeats, false);
+}
+
 cs_ret_code_t MeshModel::sendReliableMsg(const uint8_t* data, uint16_t len) {
 	return ERR_NOT_IMPLEMENTED;
 }
 
 /**
  * Send a message over the mesh via publish, without reply.
+ *
+ * Note, repeats should be larger than zero. If not, nothing will be send.
+ *
  * TODO: wait for NRF_MESH_EVT_TX_COMPLETE before sending next msg (in case of segmented msg?).
  * TODO: repeat publishing the msg.
  */
@@ -270,6 +278,14 @@ void MeshModel::handleMsg(const access_message_rx_t * accessMsg) {
 			event_t event(CS_TYPE::CMD_SET_TIME, payload, payloadSize);
 			EventDispatcher::getInstance().dispatch(event);
 		}
+		break;
+	}
+	case CS_MESH_MODEL_TYPE_PROFILE_LOCATION: {
+		if (ownMsg) {
+			break;
+		}
+		event_t event(CS_TYPE::EVT_PROFILE_LOCATION, payload, payloadSize);
+		EventDispatcher::getInstance().dispatch(event);
 		break;
 	}
 	case CS_MESH_MODEL_TYPE_CMD_NOOP: {

--- a/source/src/presence/cs_PresenceHandler.cpp
+++ b/source/src/presence/cs_PresenceHandler.cpp
@@ -48,6 +48,7 @@ void PresenceHandler::handleEvent(event_t& evt){
         adv_background_parsed_t* parsed_adv_ptr = reinterpret_cast<TYPIFY(EVT_ADV_BACKGROUND_PARSED)*>(evt.data);
         profile = parsed_adv_ptr->profileId;
         location = parsed_adv_ptr->locationId;
+		//LOGd("Location [phone]: %x %x", profile, location);
         break;
     }
     case CS_TYPE::EVT_PROFILE_LOCATION: {

--- a/source/src/processing/behaviour/cs_Behaviour.cpp
+++ b/source/src/processing/behaviour/cs_Behaviour.cpp
@@ -97,7 +97,7 @@ bool Behaviour::_isValid(PresenceStateDescription currentpresence){
 }
 
 void Behaviour::print() const {
-    uint32_t rooms[2] = {
+    [[maybe_unused]] uint32_t rooms[2] = {
         static_cast<uint32_t>(presenceCondition.pred.RoomsBitMask >> 0 ),
         static_cast<uint32_t>(presenceCondition.pred.RoomsBitMask >> 32)
     };

--- a/source/src/processing/behaviour/cs_BehaviourHandler.cpp
+++ b/source/src/processing/behaviour/cs_BehaviourHandler.cpp
@@ -59,8 +59,8 @@ void BehaviourHandler::update(){
     } 
 
     uint64_t p = presence.value();
-    uint32_t p0 = p & 0xffffffff;
-    uint32_t p1 = (p>>32) & 0xffffffff;
+    [[maybe_unused]] uint32_t p0 = p & 0xffffffff;
+    [[maybe_unused]] uint32_t p1 = (p>>32) & 0xffffffff;
     LOGd("presencedescription: %x %x", p1,p0);
 
     auto intendedState = computeIntendedState(time, presence.value());

--- a/source/src/protocol/mesh/cs_MeshModelPacketHelper.cpp
+++ b/source/src/protocol/mesh/cs_MeshModelPacketHelper.cpp
@@ -55,6 +55,8 @@ bool isValidMeshPayload(cs_mesh_model_msg_type_t type, uint8_t* payload, size16_
 		return state0IsValid((cs_mesh_model_msg_state_0_t*)payload, payloadSize);
 	case CS_MESH_MODEL_TYPE_STATE_1:
 		return state1IsValid((cs_mesh_model_msg_state_1_t*)payload, payloadSize);
+	case CS_MESH_MODEL_TYPE_PROFILE_LOCATION:
+		return profileLocationIsValid((cs_mesh_model_msg_profile_location_t*)payload, payloadSize);
 	}
 	return false;
 }
@@ -81,6 +83,10 @@ bool state0IsValid(const cs_mesh_model_msg_state_0_t* packet, size16_t size) {
 
 bool state1IsValid(const cs_mesh_model_msg_state_1_t* packet, size16_t size) {
 	return size == sizeof(cs_mesh_model_msg_state_1_t);
+}
+
+bool profileLocationIsValid(const cs_mesh_model_msg_profile_location_t* packet, size16_t size) {
+	return size == sizeof(cs_mesh_model_msg_profile_location_t);
 }
 
 bool keepAliveStateIsValid(const cs_mesh_model_msg_keep_alive_t* packet, size16_t size) {

--- a/source/src/storage/cs_StateData.cpp
+++ b/source/src/storage/cs_StateData.cpp
@@ -285,6 +285,7 @@ cs_ret_code_t getDefault(cs_state_data_t & data, const boards_config_t& boardsCo
 	case CS_TYPE::EVT_BEHAVIOUR_SWITCH_STATE:
 	case CS_TYPE::CMD_SET_RELAY:
 	case CS_TYPE::CMD_SET_DIMMER:
+	case CS_TYPE::EVT_PROFILE_LOCATION:
 		return ERR_NOT_FOUND;
 	}
 	return ERR_NOT_FOUND;
@@ -430,6 +431,7 @@ PersistenceMode DefaultLocation(CS_TYPE const & type) {
 	case CS_TYPE::EVT_BEHAVIOUR_SWITCH_STATE:
 	case CS_TYPE::CMD_SET_RELAY:
 	case CS_TYPE::CMD_SET_DIMMER:
+	case CS_TYPE::EVT_PROFILE_LOCATION:
 		return PersistenceMode::RAM;
 	}
 	// should not reach this


### PR DESCRIPTION
The location information is send as "background advertisements" from a phone.

Now, they are also communicated to other Crownstones in the mesh.

+ A `MESH_SCANNER` option to disable the (active) scanner in the mesh for debugging purposes.
+ Erase/reset a particular board in a branch (rather than the last one in build/ general).
+ Create a `EVT_PROFILE_LOCATION` type.
+ In PresenceHandler handle besides `EVT_ADV_BACKGROUND_PARSED` also `EVT_PROFILE_LOCATION` events.
+ Actually send them over the mesh with `sendProfileLocation`.

See for more info https://github.com/crownstone/bluenet/issues/82.

Things that might be considered:

+ Filtering in the `PresenceHandler` when the state actually does not change. Then actually decide to send an `EVT_PROFILE_LOCATION` update regularly (not all the time, but also not only at state changes).
+ Sending `EVT_PROFILE_LOCATION` at regular times to anticipate situation where there is no smartphone around, but when there is a wearable present. 