### PR TITLE
Adding some extra dependencies between targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(DOWNLOAD_CROWNSTONE_PYTHON_LIBS           "Download Crownstone Python lib
 option(COMPILE_FOR_HOST                          "Compile for host"                      OFF)
 option(PYTHON_SETUP_VENV                         "Setup python virtual env for user"     OFF)
 option(AUTO_UPDATE_TOOLS                         "Auto-update tools on building bluenet" OFF)
+option(FACTORY_IMAGE                             "Create factory image"                  OFF)
 
 if(NOT CONFIG_DIR)
 	set(CONFIG_DIR "config")
@@ -926,12 +927,17 @@ if(FACTORY_IMAGE)
 		fill(${PRODUCTION_RUN_HOUSING} PRODUCTION_RUN_HOUSING 8 "F" "0x")
 	endif()
 
-	set(SREC_CAT_UICR_BOOTLOADER        "-exclude;0x10001014;0x10001018;-generate;0x10001014;0x10001018;-constant-l-e;${UICR_BOOTLOADER_ADDRESS};4")
-	set(SREC_CAT_MBR_SETTINGS           "-exclude;0x10001018;0x1000101C;-generate;0x10001018;0x1000101C;-constant-l-e;${MBR_SETTINGS};4")
-	set(SREC_CAT_HARDWARE_BOARD         "-exclude;0x10001084;0x10001088;-generate;0x10001084;0x10001088;-constant-l-e;${HARDWARE_BOARD_HEX};4")
-	set(SREC_CAT_PRODUCT_FAMILY_TYPE    "-exclude;0x10001088;0x1000108C;-generate;0x10001088;0x1000108C;-constant-l-e;${PRODUCT_FAMILY_TYPE};4")
-	set(SREC_CAT_MAJOR_MINOR_PATCH      "-exclude;0x1000108C;0x10001090;-generate;0x1000108C;0x10001090;-constant-l-e;${MAJOR_MINOR_PATCH};4")
-	set(SREC_CAT_PRODUCTION_RUN_HOUSING "-exclude;0x10001090;0x10001094;-generate;0x10001090;0x10001094;-constant-l-e;${PRODUCTION_RUN_HOUSING};4")
+	set(CONSTANT_STRING "-l-e-constant")
+	if(SRECORD_NEW_VERSION)
+		set(CONSTANT_STRING "-constant-l-e")
+	endif()
+
+	set(SREC_CAT_UICR_BOOTLOADER        "-exclude;0x10001014;0x10001018;-generate;0x10001014;0x10001018;${CONSTANT_STRING};${UICR_BOOTLOADER_ADDRESS};4")
+	set(SREC_CAT_MBR_SETTINGS           "-exclude;0x10001018;0x1000101C;-generate;0x10001018;0x1000101C;${CONSTANT_STRING};${MBR_SETTINGS};4")
+	set(SREC_CAT_HARDWARE_BOARD         "-exclude;0x10001084;0x10001088;-generate;0x10001084;0x10001088;${CONSTANT_STRING};${HARDWARE_BOARD_HEX};4")
+	set(SREC_CAT_PRODUCT_FAMILY_TYPE    "-exclude;0x10001088;0x1000108C;-generate;0x10001088;0x1000108C;${CONSTANT_STRING};${PRODUCT_FAMILY_TYPE};4")
+	set(SREC_CAT_MAJOR_MINOR_PATCH      "-exclude;0x1000108C;0x10001090;-generate;0x1000108C;0x10001090;${CONSTANT_STRING};${MAJOR_MINOR_PATCH};4")
+	set(SREC_CAT_PRODUCTION_RUN_HOUSING "-exclude;0x10001090;0x10001094;-generate;0x10001090;0x10001094;${CONSTANT_STRING};${PRODUCTION_RUN_HOUSING};4")
 
 	string(TIMESTAMP FACTORY_IMAGE_TIMESTAMP "%Y-%U")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+message(STATUS "Version of cmake: ${CMAKE_VERSION}")
+
 cmake_minimum_required(VERSION 3.10)
 
 #######################################################################################################################
@@ -49,7 +51,7 @@ set(CMAKE_INSTALL_PREFIX                         ${CMAKE_SOURCE_DIR}/bin)
 set(ADD_TO_DEFAULT_BUILD_TARGET                  ALL)
 
 set(PYTHON_REQUIRED OFF)
-if(DOWNLOAD_CSUTIL OR DOWNLOAD_NRFUTIL OR DOWNLOAD_BLUENET_LIB_LOGS OR DOWNLOAD_CROWNSTONE_PYTHON_LIBS)
+if(DOWNLOAD_CSUTIL OR DOWNLOAD_NRFUTIL OR DOWNLOAD_BLUENET_LIB_LOGS OR DOWNLOAD_CROWNSTONE_PYTHON_LIBS OR DOWNLOAD_NRFCONNECT OR DOWNLOAD_NRFCONNECT_PROGRAMMER)
 	message(STATUS "One of the download options requires python")
 	set(PYTHON_REQUIRED ON)
 else()
@@ -143,6 +145,12 @@ if(PYTHON_REQUIRED)
 			message(WARNING "Virtual environment not detected! Set it up or set PYTHON_SETUP_VENV to ON.")
 		endif()
 	endif()
+endif()
+
+if(DOWNLOAD_NRFCONNECT OR DOWNLOAD_NRFCONNECT_PROGRAMMER)
+	message(STATUS "Assumed to be installed for nrfconnect: libudev, npm, make, gcc")
+	find_package(udev REQUIRED)
+	message(STATUS "Found library at: ${UDEV_LIBRARIES}")
 endif()
 
 include(ExternalProject)
@@ -361,9 +369,9 @@ ExternalProject_Add(${NORDIC_SDK_TARGET}
 	GIT_TAG ${NORDIC_SDK_GIT_TAG}
 	GIT_CONFIG advice.detachedHead=false
 	SOURCE_DIR ${NRF5_DIR}
-	CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "Skipping configure step."
-	BUILD_COMMAND ${CMAKE_COMMAND} -E echo "Skipping build step."
-	INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Skipping install step."
+	CONFIGURE_COMMAND ""
+	BUILD_COMMAND ""
+	INSTALL_COMMAND ""
 	)
 
 if(COMPILE_FOR_HOST)
@@ -374,9 +382,10 @@ if(COMPILE_FOR_HOST)
 		GIT_TAG host
 		GIT_CONFIG advice.detachedHead=false
 		SOURCE_DIR ${HOST_NRF5_DIR}
-		CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "Skipping configure step."
-		BUILD_COMMAND ${CMAKE_COMMAND} -E echo "Skipping build step."
-		INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Skipping install step."
+		CONFIGURE_COMMAND ""
+		BUILD_COMMAND ""
+		INSTALL_COMMAND ""
+		PATCH_COMMAND ""
 		)
 endif()
 
@@ -388,10 +397,10 @@ ExternalProject_Add(${MESH_SDK_TARGET}
 	GIT_TAG ${MESH_SDK_GIT_TAG}
 	GIT_CONFIG advice.detachedHead=false
 	SOURCE_DIR ${MESH_SDK_DIR}
-	CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "Skipping configure step."
-	BUILD_COMMAND ${CMAKE_COMMAND} -E echo "Skipping build step."
-	INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Skipping install step."
-	PATCH_COMMAND ${CMAKE_COMMAND} -E echo "Skipping patch step."
+	CONFIGURE_COMMAND ""
+	BUILD_COMMAND ""
+	INSTALL_COMMAND ""
+	PATCH_COMMAND ""
 	)
 
 list(APPEND CMAKE_BLUENET_ARGS "-DMESH_SDK_DIR:STRING=${MESH_SDK_DIR}")
@@ -406,10 +415,14 @@ if(DOWNLOAD_JLINK)
 		URL_MD5 ${JLINK_MD5}
 		DOWNLOAD_NO_EXTRACT 1
 		SOURCE_DIR ${WORKSPACE_DIR}/tools/jlink
-		CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "Skipping configure step."
-		BUILD_COMMAND ${CMAKE_COMMAND} -E echo "Skipping build step."
-		INSTALL_COMMAND ${SUPERUSER_SWITCH} dpkg -i ${WORKSPACE_DIR}/downloads/${JLINK_DEB_FILE}
-		# USES_TERMINAL_INSTALL 1 # Does not actually work
+		CONFIGURE_COMMAND ""
+		BUILD_COMMAND ""
+		PATCH_COMMAND ""
+		INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "-- Target jlink has user interaction for installation"
+			COMMAND ${CMAKE_COMMAND} -E echo "-- This might halt the process half-way"
+			COMMAND ${CMAKE_COMMAND} -E echo "-- and show \"[sudo] password for ...:\" in the middle of the log"
+			COMMAND ${SUPERUSER_SWITCH} dpkg -i ${WORKSPACE_DIR}/downloads/${JLINK_DEB_FILE}
+		USES_TERMINAL_INSTALL ON
 		)
 endif()
 
@@ -418,9 +431,9 @@ ExternalProject_Add(gcc_arm_none_eabi
 	URL ${GCC_ARM_NONE_EABI_DOWNLOAD_URL}
 	URL_MD5 ${GCC_ARM_NONE_EABI_MD5}
 	SOURCE_DIR ${WORKSPACE_DIR}/tools/gcc_arm_none_eabi
-	CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "Skipping configure step."
-	BUILD_COMMAND ${CMAKE_COMMAND} -E echo "Skipping build step."
-	INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Skipping install step."
+	CONFIGURE_COMMAND ""
+	BUILD_COMMAND ""
+	INSTALL_COMMAND ""
 	)
 
 set(COMPILER_PATH ${WORKSPACE_DIR}/tools/gcc_arm_none_eabi)
@@ -434,10 +447,16 @@ if(DOWNLOAD_NRFJPROG)
 		URL ${NRFJPROG_DOWNLOAD_URL}
 		URL_MD5 ${NRFJPROG_MD5}
 		SOURCE_DIR ${WORKSPACE_DIR}/tools/nrfjprog
-		CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "Skipping configure step."
-		BUILD_COMMAND ${CMAKE_COMMAND} -E echo "Skipping build step."
-		INSTALL_COMMAND ${SUPERUSER_SWITCH} dpkg -i ${WORKSPACE_DIR}/tools/nrfjprog/${NRFJPROG_DEB_FILE}
+		CONFIGURE_COMMAND ""
+		BUILD_COMMAND ""
+		INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "-- Target nrfjprog has user interaction for installation"
+			COMMAND ${CMAKE_COMMAND} -E echo "-- This might halt the process half-way"
+			COMMAND ${CMAKE_COMMAND} -E echo "-- and show \"[sudo] password for ...:\" in the middle of the log"
+			COMMAND ${SUPERUSER_SWITCH} dpkg -i ${WORKSPACE_DIR}/tools/nrfjprog/${NRFJPROG_DEB_FILE}
 		)
+	if(JLINK_TARGET)
+		add_dependencies(${NRFJPROG_TARGET} ${JLINK_TARGET})
+	endif()
 endif()
 
 if(DOWNLOAD_NRFUTIL)
@@ -463,10 +482,13 @@ if(DOWNLOAD_NRFCONNECT)
 		GIT_CONFIG advice.detachedHead=false
 		SOURCE_DIR ${WORKSPACE_DIR}/tools/nrfconnect/pc-nrfconnect-core
 		BINARY_DIR ${WORKSPACE_DIR}/tools/nrfconnect/pc-nrfconnect-core
-		CONFIGURE_COMMAND ${SUPERUSER_SWITCH} apt-get install -y build-essential python2.7 libudev-dev libgconf-2-4
+		CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "-- Target git_nrf_connect_core has user interaction for installation"
+			COMMAND ${CMAKE_COMMAND} -E echo "-- This might halt the process half-way"
+			COMMAND ${CMAKE_COMMAND} -E echo "-- and show \"[sudo] password for ...:\" in the middle of the log"
+			COMMAND ${SUPERUSER_SWITCH} apt-get install -y build-essential python2.7 libudev-dev libgconf-2-4
 		BUILD_COMMAND npm install
 		INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${WORKSPACE_DIR}/tools/nrfconnect_apps
-		COMMAND ${CMAKE_COMMAND} -E create_symlink ${WORKSPACE_DIR}/tools/nrfconnect_apps $ENV{HOME}/.nrfconnect-apps/local
+			COMMAND ${CMAKE_COMMAND} -E create_symlink ${WORKSPACE_DIR}/tools/nrfconnect_apps $ENV{HOME}/.nrfconnect-apps/local
 		)
 endif()
 
@@ -480,7 +502,7 @@ if(DOWNLOAD_NRFCONNECT_PROGRAMMER)
 		BINARY_DIR ${WORKSPACE_DIR}/tools/nrfconnect_apps/pc-nrfconnect-programmer
 		CONFIGURE_COMMAND ${SUPERUSER_SWITCH} apt-get install -y build-essential python2.7 libudev-dev libgconf-2-4
 		BUILD_COMMAND npm install
-		INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Skipping install step."
+		INSTALL_COMMAND ""
 		)
 endif()
 
@@ -495,9 +517,9 @@ if(DOWNLOAD_CSUTIL)
 		GIT_CONFIG advice.detachedHead=false
 		SOURCE_DIR ${WORKSPACE_DIR}/tools/csutil
 		BINARY_DIR ${WORKSPACE_DIR}/tools/csutil
-		CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "Skipping configure step."
-		BUILD_COMMAND ${CMAKE_COMMAND} -E echo "Skipping build step."
-		INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Skipping install step."
+		CONFIGURE_COMMAND ""
+		BUILD_COMMAND ""
+		INSTALL_COMMAND ""
 		DEPENDS ${PYTHON_SETUP_TARGET} ${PYTHON_TEST_VENV_TARGET}
 		)
 endif()
@@ -544,7 +566,9 @@ add_custom_target(${TOOLS_TARGET} ${ADD_TO_DEFAULT_BUILD_TARGET}
 	COMMAND ${CMAKE_COMMAND} -E echo "-- Install supporting tools"
 	WORKING_DIRECTORY ${WORKSPACE_DIR}
 	COMMENT "Install supporting tools"
-	DEPENDS ${BLUENET_LIB_LOGS_TARGET} ${NRFUTIL_TARGET}
+	DEPENDS
+		${BLUENET_LIB_LOGS_TARGET}
+		${NRFUTIL_TARGET}
 	)
 
 if(FACTORY_IMAGE)
@@ -614,6 +638,12 @@ add_custom_target(micro_eec
 add_custom_target(target_depend
 	COMMAND cd ${BOARD_TARGET} && test -f "Makefile" && make depend || echo "-- First install"
 	COMMENT "Run make depend in target directory"
+	DEPENDS
+	${NORDIC_SDK_TARGET}
+	${MESH_SDK_TARGET}
+	${JLINK_TARGET}
+	${NRFUTIL_TARGET}
+	${BLUENET_LIB_LOGS_TARGET}
 	)
 
 #######################################################################################################################
@@ -644,9 +674,7 @@ if(EXISTS ${BOARD_CONFIG_DIR_FULL}/CMakeBuild.overwrite.config)
 endif()
 
 if(NOT FACTORY_IMAGE)
-	add_dependencies(bluenet gcc_arm_none_eabi)
-	add_dependencies(bluenet ${NORDIC_SDK_TARGET})
-	add_dependencies(bluenet ${MESH_SDK_TARGET})
+	# No extra dependencies, already included through micro-eec target and target_depend targets
 
 	if(AUTO_UPDATE_TOOLS)
 		message(STATUS "The option AUTO_UPDATE_TOOLS is set to ON.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,8 @@ message(STATUS "Source dir ${CMAKE_SOURCE_DIR}")
 message(STATUS "Build dir ${CMAKE_BINARY_DIR}")
 message(STATUS "Installation dir with binaries ${CMAKE_INSTALL_PREFIX}")
 
+# FindGit and FindWget are standard cmake modules, see
+# https://cmake.org/cmake/help/latest/manual/cmake-modules.7.html
 find_package(Git REQUIRED)
 if(NOT Git_FOUND)
 	message(FATAL_ERROR "Installation requires git, install with something like `sudo apt install git`")
@@ -151,6 +153,9 @@ endif()
 if(DOWNLOAD_NRFCONNECT OR DOWNLOAD_NRFCONNECT_PROGRAMMER)
 	message(STATUS "Assumed to be installed for nrfconnect: libudev, npm, make, gcc")
 	find_package(udev REQUIRED)
+	if(NOT UDEV_FOUND)
+		message(FATAL_ERROR "The nrfconnect tools require libudev")
+	endif()
 	message(STATUS "Found library at: ${UDEV_LIBRARIES}")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ list(APPEND CMAKE_BLUENET_ARGS "-DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}")
 
 message(STATUS "Assumed to be installed for normal development: git, wget, make")
 message(STATUS "Assumed to be installed for tools around development: python")
-message(STATUS "Assumed to be installed to generate releases: pass, srec_cat")
+message(STATUS "Assumed to be installed to generate factory images: pass, srec_cat, libarchive-zip-perl")
 
 message(STATUS "The CPU on which CMake is running, arch=${CMAKE_HOST_SYSTEM_PROCESSOR}")
 
@@ -347,7 +347,7 @@ if(PYTHON_SETUP_VENV)
 		COMMAND apt-cache policy python3-venv > ${CMAKE_BINARY_DIR}/.apt-cache
 		COMMAND cat ${CMAKE_BINARY_DIR}/.apt-cache | grep 'Installed:' | cut -f2 -d':' > ${CMAKE_BINARY_DIR}/.apt-cache.installed
 		COMMAND cat ${CMAKE_BINARY_DIR}/.apt-cache | grep 'Candidate:' | cut -f2 -d':' > ${CMAKE_BINARY_DIR}/.apt-cache.candidate
-		COMMAND diff ${CMAKE_BINARY_DIR}/.apt-cache.candidate ${CMAKE_BINARY_DIR}/.apt-cache.installed 1>/dev/null 2>&1 && echo '-- Already uptodate' || ${SUPERUSER_SWITCH} apt-get install -y python3-venv
+		COMMAND diff ${CMAKE_BINARY_DIR}/.apt-cache.candidate ${CMAKE_BINARY_DIR}/.apt-cache.installed 1>/dev/null 2>&1 && echo '-- Package python3-venv already installed' || ${SUPERUSER_SWITCH} apt-get install -y python3-venv
 		COMMAND ${CMAKE_COMMAND} -E make_directory ${PYTHON_CROWNSTONE_VENV_PATH}
 		COMMAND ${Python_EXECUTABLE} -m venv ${PYTHON_CROWNSTONE_VENV_PATH}
 		COMMAND ${CMAKE_COMMAND} -E echo "-- Make sure to run the following command:"
@@ -948,9 +948,21 @@ if(FACTORY_IMAGE)
 
 	fill(${FACTORY_IMAGE_SOFTWARE_VERSION} FACTORY_IMAGE_SOFTWARE_VERSION 4 "0" "")
 
-	#	set(FACTORY_IMAGE_OUTPUT_FILE_NAME "${FACTORY_IMAGE_SOFTWARE_NAME}_${FACTORY_IMAGE_HARDWARE_NAME}_${FACTORY_IMAGE_TIMESTAMP}.hex")
+	# Check some stuff on the previously generated binaries that go into the factory image
+	set(CHECK_FACTORY_IMAGE_CONDITIONS check_factory_image_conditions)
+	message(STATUS "Check factory image conditions before generating it")
+	message(STATUS "This requires crc32 on the command line (e.g. apt install libarchive-zip-perl")
+	string(REGEX REPLACE "[.]hex$" ".bin" FACTORY_IMAGE_APPLICATION_BIN_FILE "${FACTORY_IMAGE_APPLICATION_HEX_FILE}")
+	message(STATUS "We will compare the crc32 of ${FACTORY_IMAGE_APPLICATION_BIN_FILE} with the checksum in ${FACTORY_IMAGE_BOOTLOADER_SETTINGS_HEX_FILE}")
+	add_custom_target(${CHECK_FACTORY_IMAGE_CONDITIONS}
+		COMMAND test -f "${FACTORY_IMAGE_APPLICATION_BIN_FILE}" && exit 0 || echo "Application missing. No such file: ${FACTORY_IMAGE_APPLICATION_BIN_FILE}" && echo && exit 1
+		COMMAND test -f "${FACTORY_IMAGE_BOOTLOADER_SETTINGS_HEX_FILE}" && exit 0 || echo "Bootloader settings missing. No such file: ${FACTORY_IMAGE_BOOTLOADER_SETTINGS_HEX_FILE}" && echo && exit 1
+		COMMAND nrfutil settings display "${FACTORY_IMAGE_BOOTLOADER_SETTINGS_HEX_FILE}" | grep 'Application CRC' | cut -f2 -d':' | tr -d ' ' | tr '[:upper:]' '[:lower:]' | sed 's/0x//g' > "${CMAKE_BINARY_DIR}/.nrfutil_app_crc"
+		COMMAND crc32 "${FACTORY_IMAGE_APPLICATION_BIN_FILE}" > "${CMAKE_BINARY_DIR}/.cli_app_crc"
+		COMMAND diff ${CMAKE_BINARY_DIR}/.nrfutil_app_crc ${CMAKE_BINARY_DIR}/.cli_app_crc 1>/dev/null 2>&1 && echo '-- Application checksum matches' && exit 0 || echo "Application CRC does not match!" && exit 1
+	)
+
 	set(FACTORY_IMAGE_OUTPUT_FILE_NAME "${FACTORY_IMAGE_HARDWARE_CONFIG}/software_${FACTORY_IMAGE_SOFTWARE_VERSION}/factory-image.hex")
-	#	set(FACTORY_IMAGE_OUTPUT_FILE_NAME "factory-image.hex")
 	set(FACTORY_IMAGE_PATH_NAME factory-images/${FACTORY_IMAGE_HARDWARE_CONFIG}/software_${FACTORY_IMAGE_SOFTWARE_VERSION})
 
 	# Add this target by default to make all when in factory image creation mode
@@ -983,6 +995,7 @@ if(FACTORY_IMAGE)
 		COMMAND echo 'srec_cat ${FACTORY_IMAGE_APPLICATION_HEX_FILE} -intel ${SREC_CAT_UICR_BOOTLOADER} ${SREC_CAT_MBR_SETTINGS} ${SREC_CAT_HARDWARE_BOARD} ${SREC_CAT_PRODUCT_FAMILY_TYPE} ${SREC_CAT_MAJOR_MINOR_PATCH} ${SREC_CAT_PRODUCTION_RUN_HOUSING} ${FACTORY_IMAGE_BOOTLOADER_HEX_FILE} -intel ${FACTORY_IMAGE_BOOTLOADER_SETTINGS_HEX_FILE} -intel ${FACTORY_IMAGE_SOFTDEVICE_HEX_FILE} -intel -o factory-images/${FACTORY_IMAGE_OUTPUT_FILE_NAME} -intel'
 		COMMAND srec_cat ${FACTORY_IMAGE_APPLICATION_HEX_FILE} -intel ${SREC_CAT_UICR_BOOTLOADER} ${SREC_CAT_MBR_SETTINGS} ${SREC_CAT_HARDWARE_BOARD} ${SREC_CAT_PRODUCT_FAMILY_TYPE} ${SREC_CAT_MAJOR_MINOR_PATCH} ${SREC_CAT_PRODUCTION_RUN_HOUSING} ${FACTORY_IMAGE_BOOTLOADER_HEX_FILE} -intel ${FACTORY_IMAGE_BOOTLOADER_SETTINGS_HEX_FILE} -intel ${FACTORY_IMAGE_SOFTDEVICE_HEX_FILE} -intel -o factory-images/${FACTORY_IMAGE_OUTPUT_FILE_NAME} -intel
 		COMMENT "Generate a factory image"
+		DEPENDS ${CHECK_FACTORY_IMAGE_CONDITIONS}
 		)
 
 	message(STATUS "Install binary into ${CMAKE_BINARY_DIR}/${FACTORY_IMAGE_PATH_NAME} dir")

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -786,6 +786,7 @@ else()
 			COMMAND ${CMAKE_COMMAND} -E echo "** Firmware version: ${FIRMWARE_VERSION}"
 			COMMAND ${CMAKE_COMMAND} -E echo "** Bootloader version: ${BOOTLOADER_VERSION}"
 			COMMAND ${CMAKE_COMMAND} -E echo "** Use files in directory: ${CMAKE_BINARY_DIR}"
+			COMMAND ${CMAKE_COMMAND} -E echo "nrfutil settings generate --family NRF52 --application "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.hex" --application-version ${FIRMWARE_DFU_VERSION} --bootloader-version ${BOOTLOADER_DFU_VERSION} --bl-settings-version 2 ${BOOTLOADER_HEX_FILE}"
 			COMMAND nrfutil settings generate --family NRF52 --application "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.hex" --application-version ${FIRMWARE_DFU_VERSION} --bootloader-version ${BOOTLOADER_DFU_VERSION} --bl-settings-version 2 "${BOOTLOADER_HEX_FILE}" 
 			COMMAND ${CMAKE_OBJCOPY_OVERLOAD} -I ihex ${BOOTLOADER_HEX_FILE} -O binary ${BOOTLOADER_BIN_FILE}
 			COMMAND ${CMAKE_COMMAND} -E echo "** Generated file: ${BOOTLOADER_HEX_FILE}"

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -8,7 +8,7 @@
 # Copyright © 2013 Crownstone
 #######################################################################################################################
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 if(COMMAND cmake_policy)
 	# only interpret arguments as variables when unquoted

--- a/source/bootloader/CMakeLists.txt
+++ b/source/bootloader/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 # Set application shorthand
 SET(APPLICATION_SHORTHAND "bootloader")
@@ -7,17 +7,9 @@ SET(APPLICATION_SHORTHAND "bootloader")
 SET(PROJECT_NAME ${APPLICATION_SHORTHAND})
 
 # Start a project
-PROJECT(${PROJECT_NAME}) 
-
-# Enabling C and CXX might lead to problems because we are cross-compiling, check in later CMake versions of this is
-# still the case
-#enable_language(CXX)
-#set(CMAKE_CXX_STANDARD 17)
-#set(CMAKE_CXX_STANDARD_REQUIRED on)
-#set(CMAKE_CXX_EXTENSIONS OFF)
+PROJECT(${PROJECT_NAME})
 
 # The directory with some of the FindXXX modules
-#SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_MODULE_PATH};${CMAKE_SOURCE_DIR}/conf;${CMAKE_SOURCE_DIR}/conf/cmake")
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${DEFAULT_MODULES_PATH}")
 MESSAGE(STATUS "bootloader: Search for FindX files in ${CMAKE_MODULE_PATH}")
 

--- a/source/conf/cmake/modules/Findpass.cmake
+++ b/source/conf/cmake/modules/Findpass.cmake
@@ -1,15 +1,19 @@
-# - Try to find LibXml2
+# - Try to find pass
+#
 # Once done this will define
 #  PASS_FOUND - System has pass
 #  PASS_EXECUTABLE - The pass executable
 
-find_package(PkgConfig)
-pkg_check_modules(PASS QUIET pass)
-
-if(PASS_EXECUTABLE)
-	# in cache already
-	set(PASS_FOUND TRUE)
-else()
-	find_program(PASS_EXECUTABLE NAMES pass)
+# Check if utility has already been found before and is present in the cache
+# (We assume that it has not been removed since then.)
+if(PASS_FOUND)
+	return()
 endif()
+
+# We won't be using pkg-config for binaries
+find_program(PASS_EXECUTABLE NAMES pass)
+
+# If XXX_EXECUTABLE is set, also set e.g. XXX_FOUND
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(pass DEFAULT_MSG PASS_EXECUTABLE)
 

--- a/source/conf/cmake/modules/Findsrecord.cmake
+++ b/source/conf/cmake/modules/Findsrecord.cmake
@@ -4,13 +4,16 @@
 #  SRECORD_FOUND      - System has srecord
 #  SRECORD_EXECUTABLE - The srecord executable
 
-find_package(PkgConfig)
-pkg_check_modules(SRECORD QUIET srecord)
-
-if(SRECORD_EXECUTABLE)
-	# in cache already
-	set(SRECORD_FOUND TRUE)
-else()
-	find_program(SRECORD_EXECUTABLE NAMES srec_cat)
+# Check if utility has already been found before and is present in the cache
+# (We assume that it has not been removed since then.)
+if(SRECORD_FOUND)
+	return()
 endif()
+
+# We won't be using pkg-config for binaries
+find_program(SRECORD_EXECUTABLE NAMES srec_cat)
+
+# If XXX_EXECUTABLE is set, also set e.g. XXX_FOUND
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(srecord DEFAULT_MSG SRECORD_EXECUTABLE)
 

--- a/source/conf/cmake/modules/Findsrecord.cmake
+++ b/source/conf/cmake/modules/Findsrecord.cmake
@@ -1,7 +1,8 @@
-# - Try to find LibXml2
+# - Try to find srecord
+
 # Once done this will define
-#  SRECORD_FOUND - System has pass
-#  SRECORD_EXECUTABLE - The pass executable
+#  SRECORD_FOUND      - System has srecord
+#  SRECORD_EXECUTABLE - The srecord executable
 
 find_package(PkgConfig)
 pkg_check_modules(SRECORD QUIET srecord)

--- a/source/conf/cmake/modules/Findudev.cmake
+++ b/source/conf/cmake/modules/Findudev.cmake
@@ -1,0 +1,34 @@
+# Try to find libudev-dev
+#
+# Once done this will define
+#  UDEV_FOUND        - System has udev
+#  UDEV_LIBRARIES    - Library itself
+#  UDEV_INCLUDE_DIRS - Dirs to include
+
+# Check if udev has already been found before and is present in the cache
+# (We assume that it has not been removed since then.)
+if(UDEV_LIBRARY)
+	set(UDEV_FOUND TRUE)
+	return()
+endif()
+
+# Use pkg_config to find the library
+find_package(PkgConfig)
+pkg_check_modules(PKG_LIBUDEV QUIET libudev)
+
+# Search for libudev.h (and give pkg-config output as hints)
+find_path(UDEV_INCLUDE_DIR NAMES libudev.h
+	HINTS
+	${PKG_LIBUDEV_INCLUDE_DIRS}
+	${PKG_LIBUDEV_INCLUDEDIR}
+	)
+
+# Search for libudev.so (and give pkg-config output as hints)
+find_library(UDEV_LIBRARY NAMES udev
+	HINTS
+	${PKG_LIBUDEV_LIBDIR}
+	${PKG_LIBUDEV_LIBRARY_DIRS}
+	)
+
+set(UDEV_INCLUDE_DIRS ${UDEV_INCLUDE_DIR})
+set(UDEV_LIBRARIES ${UDEV_LIBRARY})

--- a/source/conf/cmake/modules/Findudev.cmake
+++ b/source/conf/cmake/modules/Findudev.cmake
@@ -7,8 +7,7 @@
 
 # Check if udev has already been found before and is present in the cache
 # (We assume that it has not been removed since then.)
-if(UDEV_LIBRARY)
-	set(UDEV_FOUND TRUE)
+if(UDEV_FOUND)
 	return()
 endif()
 
@@ -30,5 +29,13 @@ find_library(UDEV_LIBRARY NAMES udev
 	${PKG_LIBUDEV_LIBRARY_DIRS}
 	)
 
+# If both XXX_LIBRARY AND XXX_INCLUDE_DIR are found set e.g. XXX_FOUND
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(udev DEFAULT_MSG
+	UDEV_LIBRARY UDEV_INCLUDE_DIR)
+
 set(UDEV_INCLUDE_DIRS ${UDEV_INCLUDE_DIR})
 set(UDEV_LIBRARIES ${UDEV_LIBRARY})
+
+# Only show as advanced options in cmake gui or other editors
+mark_as_advanced(UDEV_LIBRARY UDEV_INCLUDE_DIR)


### PR DESCRIPTION
+ This should address https://github.com/crownstone/bluenet/pull/144
regarding bluenet being build before the SDK has finished updating. [1]
+ Make each CMakeLists.txt file using the same minimal version.
+ Remove some commented lines from the bootloader.
+ Start with pulling out installation requirements for nrfconnect. For
example add Findudev.cmake. [2]

[1] If this still doesn't work, we might need to resort either:

+ Defining individual steps for targets with `STEP_TARGETS build
install ... ` and explicitly adding dependencies to them.
+ Enforce a new version of cmake which might fix such dependency issues.
This can be done through pip with a python venv for example.

[2] Installation of something through running `sudo apt` is not
compatible with multiple platforms. Recommendation:

+ Use `find_package` to see if dependencies are installed.
+ If packages are not installed, direct user to do so.
+ Only automatically install packages when particular cmake option has
been set.

The advantage of this is that we won't need to ask for superuser rights.
On the other hand, by having an AUTO_INSTALL option we can keep our
continuous integration setup intact.