### PR TITLE
Bugfix. Firmware crash on board.pinDimmer = PIN_NONE

### DIFF
--- a/source/include/drivers/cs_Dimmer.h
+++ b/source/include/drivers/cs_Dimmer.h
@@ -48,15 +48,15 @@ public:
 	void setSoftOnSpeed(uint8_t speed);
 
 private:
-	uint32_t hardwareBoard;
-	uint8_t pinEnableDimmer;
+	uint32_t _hardwareBoard;
+	uint8_t _pinEnableDimmer;
 	bool _hasDimmer = false;
 
-	TYPIFY(STATE_SOFT_ON_SPEED) softOnfSpeed;
+	TYPIFY(STATE_SOFT_ON_SPEED) _softOnSpeed;
 
-	bool initialized = false;
-	bool started = false;
-	bool enabled = false;
+	bool _initialized = false;
+	bool _started = false;
+	bool _enabled = false;
 
 	void enable();
 };

--- a/source/src/drivers/cs_Dimmer.cpp
+++ b/source/src/drivers/cs_Dimmer.cpp
@@ -15,25 +15,30 @@
 #include <test/cs_Test.h>
 
 void Dimmer::init(const boards_config_t& board) {
-	hardwareBoard = board.hardwareBoard;
-	pinEnableDimmer = board.pinEnableDimmer;
+	if(_initialized) {
+		LOGw("Dimmer init was already executed.");
+		return;
+	}
+
+	_hardwareBoard = board.hardwareBoard;
+	_pinEnableDimmer = board.pinEnableDimmer;
 	_hasDimmer = board.pinDimmer != PIN_NONE;
 
 	if (!_hasDimmer) {
 		return;
 	}
 
-	if (pinEnableDimmer != PIN_NONE) {
-		nrf_gpio_cfg_output(pinEnableDimmer);
-		nrf_gpio_pin_clear(pinEnableDimmer);
+	if (_pinEnableDimmer != PIN_NONE) {
+		nrf_gpio_cfg_output(_pinEnableDimmer);
+		nrf_gpio_pin_clear(_pinEnableDimmer);
 	}
 
 	TYPIFY(CONFIG_PWM_PERIOD) pwmPeriodUs;
 	State::getInstance().get(CS_TYPE::CONFIG_PWM_PERIOD, &pwmPeriodUs, sizeof(pwmPeriodUs));
 
-	State::getInstance().get(CS_TYPE::STATE_SOFT_ON_SPEED, &softOnfSpeed, sizeof(softOnfSpeed));
+	State::getInstance().get(CS_TYPE::STATE_SOFT_ON_SPEED, &_softOnSpeed, sizeof(_softOnSpeed));
 
-	LOGd("init enablePin=%u dimmerPin=%u inverted=%u period=%u µs softOnSpeed=%u", board.pinEnableDimmer, board.pinDimmer, board.flags.dimmerInverted, pwmPeriodUs, softOnfSpeed);
+	LOGd("init enablePin=%u dimmerPin=%u inverted=%u period=%u µs softOnSpeed=%u", board.pinEnableDimmer, board.pinDimmer, board.flags.dimmerInverted, pwmPeriodUs, _softOnSpeed);
 
 	pwm_config_t pwmConfig;
 	pwmConfig.channelCount = 1;
@@ -43,7 +48,7 @@ void Dimmer::init(const boards_config_t& board) {
 
 	PWM::getInstance().init(pwmConfig);
 
-	initialized = true;
+	_initialized = true;
 }
 
 bool Dimmer::hasDimmer() {
@@ -55,18 +60,18 @@ void Dimmer::start() {
 		return;
 	}
 	LOGd("start");
-	assert(initialized == true, "Not initialized");
-	if (started) {
+	assert(_initialized == true, "Not initialized");
+	if (_started) {
 		return;
 	}
-	started = true;
+	_started = true;
 
 	enable();
 
 	TYPIFY(CONFIG_START_DIMMER_ON_ZERO_CROSSING) startDimmerOnZeroCrossing;
 	State::getInstance().get(CS_TYPE::CONFIG_START_DIMMER_ON_ZERO_CROSSING, &startDimmerOnZeroCrossing, sizeof(startDimmerOnZeroCrossing));
 
-	switch (hardwareBoard) {
+	switch (_hardwareBoard) {
 		case PCA10036:
 		case PCA10040:
 		case PCA10100:
@@ -85,13 +90,13 @@ bool Dimmer::set(uint8_t intensity, bool fade) {
 		return false;
 	}
 	LOGd("set %u fade=%u", intensity, fade);
-	assert(initialized == true, "Not initialized");
-	if (!enabled && intensity > 0) {
+	assert(_initialized == true, "Not initialized");
+	if (!_enabled && intensity > 0) {
 		LOGd("Dimmer not enabled");
 		return false;
 	}
 
-	uint8_t speed = fade ? softOnfSpeed : 100;
+	uint8_t speed = fade ? _softOnSpeed : 100;
 
 	TEST_PUSH_EXPR_D(this, "intensity", intensity);
 	PWM::getInstance().setValue(0, intensity, speed);
@@ -104,16 +109,16 @@ void Dimmer::setSoftOnSpeed(uint8_t speed) {
 		return;
 	}
 	LOGd("setSoftOnSpeed %u", speed);
-	softOnfSpeed = speed;
+	_softOnSpeed = speed;
 }
 
 void Dimmer::enable() {
 	if (!_hasDimmer) {
 		return;
 	}
-	LOGd("enable");
-	if (pinEnableDimmer != PIN_NONE) {
-		nrf_gpio_pin_set(pinEnableDimmer);
+	if (_pinEnableDimmer != PIN_NONE) {
+		LOGd("enable");
+		nrf_gpio_pin_set(_pinEnableDimmer);
+		_enabled = true;
 	}
-	enabled = true;
 }

--- a/source/src/drivers/cs_Dimmer.cpp
+++ b/source/src/drivers/cs_Dimmer.cpp
@@ -15,8 +15,6 @@
 #include <test/cs_Test.h>
 
 void Dimmer::init(const boards_config_t& board) {
-	initialized = true;
-
 	hardwareBoard = board.hardwareBoard;
 	pinEnableDimmer = board.pinEnableDimmer;
 	_hasDimmer = board.pinDimmer != PIN_NONE;
@@ -44,6 +42,8 @@ void Dimmer::init(const boards_config_t& board) {
 	pwmConfig.channels[0].inverted = board.flags.dimmerInverted;
 
 	PWM::getInstance().init(pwmConfig);
+
+	initialized = true;
 }
 
 bool Dimmer::hasDimmer() {
@@ -51,6 +51,9 @@ bool Dimmer::hasDimmer() {
 }
 
 void Dimmer::start() {
+	if (!_hasDimmer) {
+		return;
+	}
 	LOGd("start");
 	assert(initialized == true, "Not initialized");
 	if (started) {
@@ -78,6 +81,9 @@ void Dimmer::start() {
 }
 
 bool Dimmer::set(uint8_t intensity, bool fade) {
+	if (!_hasDimmer) {
+		return false;
+	}
 	LOGd("set %u fade=%u", intensity, fade);
 	assert(initialized == true, "Not initialized");
 	if (!enabled && intensity > 0) {
@@ -94,11 +100,17 @@ bool Dimmer::set(uint8_t intensity, bool fade) {
 }
 
 void Dimmer::setSoftOnSpeed(uint8_t speed) {
+	if (!_hasDimmer) {
+		return;
+	}
 	LOGd("setSoftOnSpeed %u", speed);
 	softOnfSpeed = speed;
 }
 
 void Dimmer::enable() {
+	if (!_hasDimmer) {
+		return;
+	}
 	LOGd("enable");
 	if (pinEnableDimmer != PIN_NONE) {
 		nrf_gpio_pin_set(pinEnableDimmer);

--- a/source/src/drivers/cs_Dimmer.cpp
+++ b/source/src/drivers/cs_Dimmer.cpp
@@ -59,12 +59,11 @@ void Dimmer::start() {
 	if (!_hasDimmer) {
 		return;
 	}
-	LOGd("start");
-	assert(_initialized == true, "Not initialized");
 	if (_started) {
 		return;
 	}
-	_started = true;
+	LOGd("start");
+	assert(_initialized == true, "Not initialized");
 
 	enable();
 
@@ -83,6 +82,8 @@ void Dimmer::start() {
 			PWM::getInstance().start(startDimmerOnZeroCrossing);
 			break;
 	}
+
+	_started = true;
 }
 
 bool Dimmer::set(uint8_t intensity, bool fade) {


### PR DESCRIPTION
Initialized is set to true early in init() function. Only after the
dimmer has been initialized should this be set to true.

Within init() when !_hasDimmer the function returns. It is not known to
the rest of the firmware if initialization has been successful.

The current code calls Dimmer::start() even if there's no dimmer. This
crashes the firmware.

The current patch is by adding early returns when !_hasDimmer for the
other dimmer functions. This won't have a negative effect on the current
code and leads to minimum code changes for the code that uses this
class.

The patch is motivated by being able to have firmware in the field
without IGBTs (e.g. smart outlets) and introduces minimal code changes.

Alternatively, we can:

1. Dynamically create a dimmer instance depending on its presence.
2. Remove it as a singleton.
3. Guard all calls by functionality that checks if a dimmer is present.
   With init(), with start(), with set(), with setSoftOnSpeed(), and
   with enable().

Until then I'd recommend this small patch.