### PR TITLE
Option to build offline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ option(FACTORY_IMAGE                             "Create factory image"         
 option(REQUIRE_NRFJPROG                          "Require nrfjprog"                      ON)
 option(REQUIRE_JLINK                             "Require JLink"                         ON)
 option(REQUIRE_PYTHON                            "Require python"                        OFF)
+option(BUILD_OFFLINE                             "Build offline"                         OFF)
+
+if (${BUILD_OFFLINE})
+	set_property(DIRECTORY ${myrootproject_SOURCE_DIR}
+		PROPERTY EP_UPDATE_DISCONNECTED 1)
+endif()
 
 if(NOT CONFIG_DIR)
 	set(CONFIG_DIR "config")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,12 +119,6 @@ if(FACTORY_IMAGE)
 	endif()
 endif()
 
-set(COMPILE_ON_ARM 0)
-if("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "arm*" OR "${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "aarch64")
-	message(STATUS "Host has an ARM processor")
-	set(COMPILE_ON_ARM 1)
-endif()
-
 if(REQUIRE_PYTHON)
 	# This utility is able to find either python2 or python3. Set virtual env variant to be used first.
 	set(Python_FIND_VIRTUALENV FIRST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,6 @@ option(REQUIRE_JLINK                             "Require JLink"                
 option(REQUIRE_PYTHON                            "Require python"                        OFF)
 option(BUILD_OFFLINE                             "Build offline"                         OFF)
 
-if (${BUILD_OFFLINE})
-	set_property(DIRECTORY ${myrootproject_SOURCE_DIR}
-		PROPERTY EP_UPDATE_DISCONNECTED 1)
-endif()
-
 if(NOT CONFIG_DIR)
 	set(CONFIG_DIR "config")
 endif()
@@ -36,6 +31,12 @@ set(DEFAULT_MODULES_PATH                         ${DEFAULT_CONF_CMAKE_PATH}/modu
 
 set(RELEASE_REPOSITORY                           ${WORKSPACE_DIR}/../bluenet-release CACHE STRING "Release repository")
 set(RELEASE_CANDIDATE_REPOSITORY                 ${WORKSPACE_DIR}/../bluenet-release-candidate CACHE STRING "Release candidate repository")
+
+message(STATUS "Workspace directory: ${WORKSPACE_DIR}")
+
+if (${BUILD_OFFLINE})
+	set_property(DIRECTORY ${WORKSPACE_DIR} PROPERTY EP_UPDATE_DISCONNECTED 1)
+endif()
 
 # Set build type to debug, unless specified otherwise. This prevents accidental release builds.
 if(NOT CMAKE_BUILD_TYPE)

--- a/docs/development_environment/BUILD_SYSTEM.md
+++ b/docs/development_environment/BUILD_SYSTEM.md
@@ -96,6 +96,14 @@ microapps. Just the targets are also listed through:
 
     make help
 
+# Build offline
+
+If you have worked on bluenet before (and downloaded dependencies) and subsequently you want to build the project, the `cmake` build system requires an internet connection to check if the downloaded code such as the Nordic SDK etc are still up to date. You can disable this by the following option.
+
+    cmake .. -DBUILD_OFFLINE=ON
+
+Make sure you set this back to pick up the latest changes in the project's dependencies.
+
 # Python virtual environment
 
 Although it is possible to use bluenet without a Python virtual environment, it is discouraged.


### PR DESCRIPTION
Solves https://github.com/crownstone/bluenet/issues/176

Through the option `-DBUILD_OFFLINE=ON` you can disable updates of for
example the git repositories added by ExternalProject_Add.

Of course it's the responsibility of the developer to have the required
dependencies such as the cross-compiler on their system. This option is
only useful after you have compiled before with this option disabled
(which pulls the corresponding dependencies into the project).