### PR TITLE
Add versioning to IPC

### DIFF
--- a/source/bootloader/cs_BootloaderConfig.c.in
+++ b/source/bootloader/cs_BootloaderConfig.c.in
@@ -16,7 +16,9 @@ const char g_BUILD_TYPE[]                     = CS_BUILD_TYPE;
 /*
  * Define a series of integers. Will be filled in by a cmake configure step.
  */
-const uint8_t g_BOOTLOADER_IPC_RAM_PROTOCOL   = ${BOOTLOADER_IPC_RAM_PROTOCOL};
+const uint8_t g_BOOTLOADER_IPC_RAM_MAJOR      = ${BOOTLOADER_IPC_RAM_MAJOR};
+
+const uint8_t g_BOOTLOADER_IPC_RAM_MINOR      = ${BOOTLOADER_IPC_RAM_MINOR};
 
 const uint16_t g_BOOTLOADER_DFU_VERSION       = ${BOOTLOADER_DFU_VERSION};
 

--- a/source/bootloader/cs_BootloaderConfig.h
+++ b/source/bootloader/cs_BootloaderConfig.h
@@ -12,7 +12,9 @@ extern const char g_COMPILATION_DAY[];
 
 extern const char g_BUILD_TYPE[];
 
-extern const uint8_t g_BOOTLOADER_IPC_RAM_PROTOCOL;
+extern const uint8_t g_BOOTLOADER_IPC_RAM_MAJOR;
+
+extern const uint8_t g_BOOTLOADER_IPC_RAM_MINOR;
 
 extern const uint16_t g_BOOTLOADER_DFU_VERSION;
 

--- a/source/bootloader/main.c
+++ b/source/bootloader/main.c
@@ -207,22 +207,22 @@ void set_bootloader_info() {
 	NRF_LOG_INFO("Set bootloader info");
 	NRF_LOG_FLUSH();
 
-	bluenet_ipc_bootloader_data_t bootloader_data;
-	bootloader_data.protocol    = g_BOOTLOADER_IPC_RAM_PROTOCOL;
-	bootloader_data.dfu_version = g_BOOTLOADER_DFU_VERSION;
-	bootloader_data.major       = g_BOOTLOADER_VERSION_MAJOR;
-	bootloader_data.minor       = g_BOOTLOADER_VERSION_MINOR;
-	bootloader_data.patch       = g_BOOTLOADER_VERSION_PATCH;
-	bootloader_data.prerelease  = g_BOOTLOADER_VERSION_PRERELEASE;
-	bootloader_data.build_type  = g_BOOTLOADER_BUILD_TYPE;
+	bluenet_ipc_data_t ipcData;
+	bluenet_ipc_data_header_t header;
+	header.index                      = IPC_INDEX_BOOTLOADER_VERSION;
+	header.dataSize                   = sizeof(ipcData.bootloaderData);
+	header.major                      = BLUENET_IPC_MAJOR_DEFAULT;
+	header.minor                      = BLUENET_IPC_MINOR_DEFAULT;
 
-	uint8_t size                = sizeof(bootloader_data);
+	ipcData.bootloaderData.protocol   = g_BOOTLOADER_IPC_RAM_PROTOCOL;
+	ipcData.bootloaderData.dfuVersion = g_BOOTLOADER_DFU_VERSION;
+	ipcData.bootloaderData.major      = g_BOOTLOADER_VERSION_MAJOR;
+	ipcData.bootloaderData.minor      = g_BOOTLOADER_VERSION_MINOR;
+	ipcData.bootloaderData.patch      = g_BOOTLOADER_VERSION_PATCH;
+	ipcData.bootloaderData.prerelease = g_BOOTLOADER_VERSION_PRERELEASE;
+	ipcData.bootloaderData.buildType  = g_BOOTLOADER_BUILD_TYPE;
 
-	// should not happen but we don't want asserts in the bootloader, so we just truncate the struct
-	if (size > BLUENET_IPC_RAM_DATA_ITEM_SIZE) {
-		size = BLUENET_IPC_RAM_DATA_ITEM_SIZE;
-	}
-	setRamData(IPC_INDEX_BOOTLOADER_VERSION, (uint8_t*)&bootloader_data, size);
+	setRamData(&header, ipcData.raw);
 }
 
 /**

--- a/source/bootloader/main.c
+++ b/source/bootloader/main.c
@@ -209,14 +209,15 @@ void set_bootloader_info() {
 
 	bluenet_ipc_data_t ipcData;
 
-	ipcData.bootloaderData.protocol   = g_BOOTLOADER_IPC_RAM_PROTOCOL;
-	ipcData.bootloaderData.dfuVersion = g_BOOTLOADER_DFU_VERSION;
-	ipcData.bootloaderData.major      = g_BOOTLOADER_VERSION_MAJOR;
-	ipcData.bootloaderData.minor      = g_BOOTLOADER_VERSION_MINOR;
-	ipcData.bootloaderData.patch      = g_BOOTLOADER_VERSION_PATCH;
-	ipcData.bootloaderData.prerelease = g_BOOTLOADER_VERSION_PRERELEASE;
-	ipcData.bootloaderData.buildType  = g_BOOTLOADER_BUILD_TYPE;
-	uint8_t dataSize                  = sizeof(ipcData.bootloaderData);
+	ipcData.bootloaderData.ipcDataMajor         = g_BOOTLOADER_IPC_RAM_MAJOR;
+	ipcData.bootloaderData.ipcDataMinor         = g_BOOTLOADER_IPC_RAM_MINOR;
+	ipcData.bootloaderData.dfuVersion           = g_BOOTLOADER_DFU_VERSION;
+	ipcData.bootloaderData.bootloaderMajor      = g_BOOTLOADER_VERSION_MAJOR;
+	ipcData.bootloaderData.bootloaderMinor      = g_BOOTLOADER_VERSION_MINOR;
+	ipcData.bootloaderData.bootloaderPatch      = g_BOOTLOADER_VERSION_PATCH;
+	ipcData.bootloaderData.bootloaderPrerelease = g_BOOTLOADER_VERSION_PRERELEASE;
+	ipcData.bootloaderData.bootloaderBuildType  = g_BOOTLOADER_BUILD_TYPE;
+	uint8_t dataSize                            = sizeof(ipcData.bootloaderData);
 	setRamData(IPC_INDEX_BOOTLOADER_VERSION, dataSize, ipcData.raw);
 }
 

--- a/source/bootloader/main.c
+++ b/source/bootloader/main.c
@@ -208,11 +208,6 @@ void set_bootloader_info() {
 	NRF_LOG_FLUSH();
 
 	bluenet_ipc_data_t ipcData;
-	bluenet_ipc_data_header_t header;
-	header.index                      = IPC_INDEX_BOOTLOADER_VERSION;
-	header.dataSize                   = sizeof(ipcData.bootloaderData);
-	header.major                      = BLUENET_IPC_MAJOR_DEFAULT;
-	header.minor                      = BLUENET_IPC_MINOR_DEFAULT;
 
 	ipcData.bootloaderData.protocol   = g_BOOTLOADER_IPC_RAM_PROTOCOL;
 	ipcData.bootloaderData.dfuVersion = g_BOOTLOADER_DFU_VERSION;
@@ -221,8 +216,8 @@ void set_bootloader_info() {
 	ipcData.bootloaderData.patch      = g_BOOTLOADER_VERSION_PATCH;
 	ipcData.bootloaderData.prerelease = g_BOOTLOADER_VERSION_PRERELEASE;
 	ipcData.bootloaderData.buildType  = g_BOOTLOADER_BUILD_TYPE;
-
-	setRamData(&header, ipcData.raw);
+	uint8_t dataSize                  = sizeof(ipcData.bootloaderData);
+	setRamData(IPC_INDEX_BOOTLOADER_VERSION, dataSize, ipcData.raw);
 }
 
 /**

--- a/source/bootloader/nrf_dfu_ble.c
+++ b/source/bootloader/nrf_dfu_ble.c
@@ -294,9 +294,9 @@ static uint32_t service_changed_send(void) {
 
 /**@brief Function for encoding the beginning of a response.
  *
- * @param[inout] p_buffer  The buffer to encode into.
- * @param[in]    op_code   The opcode of the response.
- * @param[in]    result    The result of the operation.
+ * @param[in,out] p_buffer  The buffer to encode into.
+ * @param[in]     op_code   The opcode of the response.
+ * @param[in]     result    The result of the operation.
  *
  * @return The length added to the buffer.
  */
@@ -312,10 +312,10 @@ static uint32_t response_prepare(uint8_t* p_buffer, uint8_t op_code, uint8_t res
  *
  * The select object response consists of a maximum object size, a firmware offset, and a CRC value.
  *
- * @param[inout] p_buffer   The buffer to encode the response into.
- * @param[in]    max_size   The maximum object size value to encode.
- * @param[in]    fw_offset  The firmware offset value to encode.
- * @param[in]    crc        The CRC value to encode.
+ * @param[in,out] p_buffer   The buffer to encode the response into.
+ * @param[in]     max_size   The maximum object size value to encode.
+ * @param[in]     fw_offset  The firmware offset value to encode.
+ * @param[in]     crc        The CRC value to encode.
  *
  * @return The length added to the buffer.
  */
@@ -330,9 +330,9 @@ static uint32_t response_select_obj_add(uint8_t* p_buffer, uint32_t max_size, ui
  *
  * The CRC response consists of a firmware offset and a CRC value.
  *
- * @param[inout] p_buffer   The buffer to encode the response into.
- * @param[in]    fw_offset  The firmware offset value to encode.
- * @param[in]    crc        The CRC value to encode.
+ * @param[in,out] p_buffer   The buffer to encode the response into.
+ * @param[in]     fw_offset  The firmware offset value to encode.
+ * @param[in]     crc        The CRC value to encode.
  *
  * @return The length added to the buffer.
  */
@@ -344,9 +344,9 @@ static uint32_t response_crc_add(uint8_t* p_buffer, uint32_t fw_offset, uint32_t
 
 /**@brief Function for appending an extended error code to the response buffer.
  *
- * @param[inout] p_buffer    The buffer to append the extended error code to.
- * @param[in]    result      The error code to append.
- * @param[in]    buf_offset  The current length of the buffer.
+ * @param[in,out] p_buffer    The buffer to append the extended error code to.
+ * @param[in]     result      The error code to append.
+ * @param[in]     buf_offset  The current length of the buffer.
  *
  * @return The length added to the buffer.
  */

--- a/source/conf/cmake/CMakeBuild.config.default
+++ b/source/conf/cmake/CMakeBuild.config.default
@@ -500,7 +500,12 @@ HEAP_SIZE=20000
 RAM_BLUENET_IPC_LENGTH=0x100
 
 # Parameters for IPC with the bootloader
-BOOTLOADER_IPC_RAM_PROTOCOL=1
+BOOTLOADER_IPC_RAM_MAJOR=1
+BOOTLOADER_IPC_RAM_MINOR=0
+
+# Parameters for bluenet to indicate compatibility with the bootloader
+BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MAJOR=1
+BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MINOR=0
 
 # Parameters for the microapps
 

--- a/source/include/cfg/cs_AutoConfig.h
+++ b/source/include/cfg/cs_AutoConfig.h
@@ -100,6 +100,9 @@ extern const int8_t g_LED2_INDEX;
 extern const int8_t g_LED3_INDEX;
 extern const int8_t g_LED4_INDEX;
 
+extern const uint8_t g_BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MAJOR;
+extern const uint8_t g_BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MINOR;
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/include/protocol/cs_MicroappPackets.h
+++ b/source/include/protocol/cs_MicroappPackets.h
@@ -25,9 +25,9 @@ constexpr uint16_t MICROAPP_UPLOAD_MAX_CHUNK_SIZE = 256;
 /**
  * Protocol version of the communication between the user and the firmware: the microapp command and result packets.
  */
-constexpr uint8_t MICROAPP_PROTOCOL               = 1;
+constexpr uint8_t MICROAPP_DATA_PROTOCOL          = 1;
 
-constexpr uint8_t MICROAPP_SDK_MAJOR              = 1;
+constexpr uint8_t MICROAPP_SDK_MAJOR              = 3;
 
 constexpr uint8_t MICROAPP_SDK_MINOR              = 0;
 
@@ -60,7 +60,7 @@ struct __attribute__((__packed__)) microapp_binary_header_t {
 };
 
 struct __attribute__((packed)) microapp_ctrl_header_t {
-	uint8_t protocol;  // Protocol of the microapp command and result packets, should match MICROAPP_PROTOCOL.
+	uint8_t protocol;  // Protocol of the microapp command and result packets, should match MICROAPP_DATA_PROTOCOL.
 	uint8_t index;     // Index of the microapp on the firmware.
 };
 
@@ -125,9 +125,10 @@ struct __attribute__((packed)) microapp_status_t {
  * Packet with all info required to upload a microapp, and to see the status of already uploaded microapps.
  */
 struct __attribute__((packed)) microapp_info_t {
-	uint8_t protocol      = MICROAPP_PROTOCOL;  // Protocol of this packet, and the microapp command packets.
-	uint8_t maxApps       = MAX_MICROAPPS;      // Maximum number of microapps.
-	uint16_t maxAppSize   = MICROAPP_MAX_SIZE;  // Maximum binary size of a microapp.
+	// Protocol of this packet, and the microapp command packets.
+	// uint8_t protocol      = MICROAPP_PROTOCOL;  // Protocol of this packet, and the microapp command packets.
+	uint8_t maxApps       = MAX_MICROAPPS;                   // Maximum number of microapps.
+	uint16_t maxAppSize   = MICROAPP_MAX_SIZE;               // Maximum binary size of a microapp.
 	uint16_t maxChunkSize = MICROAPP_UPLOAD_MAX_CHUNK_SIZE;  // Maximum chunk size for uploading a microapp.
 	uint16_t maxRamUsage  = MICROAPP_MAX_RAM;                // Maximum RAM usage of a microapp.
 	microapp_sdk_version_t sdkVersion;                       // SDK version the firmware supports.

--- a/source/include/protocol/cs_MicroappPackets.h
+++ b/source/include/protocol/cs_MicroappPackets.h
@@ -12,7 +12,7 @@
 /**
  * Max number of microapps.
  */
-constexpr uint8_t MAX_MICROAPPS                   = 1;
+constexpr uint8_t MAX_MICROAPPS                     = 1;
 
 /**
  * Max allowed chunk size when uploading a microapp.
@@ -20,22 +20,28 @@ constexpr uint8_t MAX_MICROAPPS                   = 1;
  * We could calculate this from MTU or characteristic buffer size for BLE, and UART RX buffer size for UART.
  * But let's just start with a number that fits in both.
  */
-constexpr uint16_t MICROAPP_UPLOAD_MAX_CHUNK_SIZE = 256;
+constexpr uint16_t MICROAPP_UPLOAD_MAX_CHUNK_SIZE   = 256;
 
 /**
- * Protocol version of the communication between the user and the firmware: the microapp command and result packets.
+ * Protocol version of the communication over the command handler, the microapp command and result packets.
  */
-constexpr uint8_t MICROAPP_DATA_PROTOCOL          = 1;
+constexpr uint8_t MICROAPP_CONTROL_COMMAND_PROTOCOL = 1;
 
-constexpr uint8_t MICROAPP_SDK_MAJOR              = 3;
+/**
+ * SDK major version of the data going back and forth between microapp and bluenet within the mutually shared buffers.
+ */
+constexpr uint8_t MICROAPP_SDK_MAJOR                = 1;
 
-constexpr uint8_t MICROAPP_SDK_MINOR              = 0;
+/**
+ * SDK minor version of the data going back and forth between microapp and bluenet within the mutually shared buffers.
+ */
+constexpr uint8_t MICROAPP_SDK_MINOR                = 0;
 
-constexpr uint16_t CS_FLASH_PAGE_SIZE             = 0x1000;  // Size of 1 flash page.
+constexpr uint16_t CS_FLASH_PAGE_SIZE               = 0x1000;  // Size of 1 flash page.
 
-constexpr uint16_t MICROAPP_MAX_SIZE              = (1 * CS_FLASH_PAGE_SIZE);  // Must be a multiple of flash page size.
+constexpr uint16_t MICROAPP_MAX_SIZE = (1 * CS_FLASH_PAGE_SIZE);  // Must be a multiple of flash page size.
 
-constexpr uint16_t MICROAPP_MAX_RAM               = 0x200;  // Something for now.
+constexpr uint16_t MICROAPP_MAX_RAM  = 0x200;  // Something for now.
 
 /**
  * Header of a microapp binary.
@@ -60,14 +66,17 @@ struct __attribute__((__packed__)) microapp_binary_header_t {
 };
 
 struct __attribute__((packed)) microapp_ctrl_header_t {
-	uint8_t protocol;  // Protocol of the microapp command and result packets, should match MICROAPP_DATA_PROTOCOL.
-	uint8_t index;     // Index of the microapp on the firmware.
+	// Protocol of the microapp command and result packets.
+	uint8_t protocol;
+	// Index of the microapp on the firmware.
+	uint8_t index;
 };
 
 struct __attribute__((packed)) microapp_upload_t {
 	microapp_ctrl_header_t header;
-	uint16_t offset;  // Offset in bytes of this chunk of data. Must be a multiple of 4.
-					  // Followed by a chunk of the microapp binary.
+	// Offset in bytes of this chunk of data. Must be a multiple of 4.
+	uint16_t offset;
+	// Followed by a chunk of the microapp binary.
 };
 
 /**
@@ -126,7 +135,7 @@ struct __attribute__((packed)) microapp_status_t {
  */
 struct __attribute__((packed)) microapp_info_t {
 	// Protocol of this packet, and the microapp command packets.
-	// uint8_t protocol      = MICROAPP_PROTOCOL;  // Protocol of this packet, and the microapp command packets.
+	uint8_t protocol      = MICROAPP_CONTROL_COMMAND_PROTOCOL;
 	uint8_t maxApps       = MAX_MICROAPPS;                   // Maximum number of microapps.
 	uint16_t maxAppSize   = MICROAPP_MAX_SIZE;               // Maximum binary size of a microapp.
 	uint16_t maxChunkSize = MICROAPP_UPLOAD_MAX_CHUNK_SIZE;  // Maximum chunk size for uploading a microapp.

--- a/source/shared/cs_MicroappStructs.h
+++ b/source/shared/cs_MicroappStructs.h
@@ -16,6 +16,12 @@
 
 #include <cstdint>
 
+/**
+ * Protocol version of the contents of the IPC data going back and forth between microapp and bluenet.
+ * This data currently contains a callback and a flag.
+ */
+const uint8_t MICROAPP_IPC_DATA_PROTOCOL                    = 1;
+
 /*
  * Externally determined constant sizes
  */
@@ -375,12 +381,15 @@ typedef microapp_sdk_result_t (*microappCallbackFunc)(uint8_t opcode, bluenet_io
  * The size is also defined in the parent struct: bluenet_ipc_data_t.
  * The pointer to the coargs struct can be used to switch back from the used coroutine and needs to stored somewhere
  * accessible (not in this struct).
- * The protocol version here is the protocol version of the subsequent data exchange. It is not a version of this
- * struct itself.
+ * The protocol version here is the protocol version of the subsequent data exchange. It is not a version of the IPC
+ * struct header. It is neither the protocol for "command control" (for uploading microapps).
  */
 struct __attribute__((packed)) bluenet2microapp_ipcdata_t {
-	uint8_t protocol;
+	// Data protocol (between bluenet and microapp)
+	uint8_t dataProtocol;
+	// The callback to be registered and used
 	microappCallbackFunc microappCallback;
+	// Flag to indicate that the callback is set by the microapp and the struct can be considered valid
 	uint8_t valid : 1;
 };
 

--- a/source/shared/cs_MicroappStructs.h
+++ b/source/shared/cs_MicroappStructs.h
@@ -17,15 +17,6 @@
 #include <cstdint>
 
 /*
- * Major and minor versions of the current specific code base.
- */
-
-// Major version of the protocol
-const uint8_t MICROAPP_IPC_CURRENT_PROTOCOL_MAJOR           = 1;
-// Minor version of the protocol
-const uint8_t MICROAPP_IPC_CURRENT_PROTOCOL_MINOR           = 0;
-
-/*
  * Externally determined constant sizes
  */
 

--- a/source/shared/cs_MicroappStructs.h
+++ b/source/shared/cs_MicroappStructs.h
@@ -8,11 +8,22 @@
  */
 #pragma once
 
-#ifdef __cplusplus
-#include <cstdint>
-#else
-#include <stdint.h>
+#ifndef __cplusplus
+#error "Must be compiled by g++ compiler. This is C++ code"
 #endif
+
+#include <ipc/cs_IpcRamData.h>
+
+#include <cstdint>
+
+/*
+ * Major and minor versions of the current specific code base.
+ */
+
+// Major version of the protocol
+const uint8_t MICROAPP_IPC_CURRENT_PROTOCOL_MAJOR           = 1;
+// Minor version of the protocol
+const uint8_t MICROAPP_IPC_CURRENT_PROTOCOL_MINOR           = 0;
 
 /*
  * Externally determined constant sizes
@@ -369,17 +380,29 @@ struct __attribute__((packed)) bluenet_io_buffers_t {
 typedef microapp_sdk_result_t (*microappCallbackFunc)(uint8_t opcode, bluenet_io_buffers_t*);
 
 /*
- * The layout of the struct in ramdata. We set for the microapp a protocol version so it can check itself if it is
- * compatible. The length parameter functions as a extra possible check. The callback can be used by the microapp to
- * call back into bluenet. The pointer to the coargs struct can be used to switch back from the used coroutine and
- * needs to stored somewhere accessible.
+ * The layout of the struct in ramdata. The parent struct contains major and minor for struct changes.
+ * The size is also defined in the parent struct: bluenet_ipc_data_t.
+ * The pointer to the coargs struct can be used to switch back from the used coroutine and needs to stored somewhere
+ * accessible (not in this struct).
+ * The protocol version here is the protocol version of the subsequent data exchange. It is not a version of this
+ * struct itself.
  */
 struct __attribute__((packed)) bluenet2microapp_ipcdata_t {
 	uint8_t protocol;
-	uint8_t length;
 	microappCallbackFunc microappCallback;
-	bool valid;
+	uint8_t valid : 1;
 };
+
+/**
+ * Make data available as union again, but now as bluenet_ipc_data_cpp_t struct rather than a bluenet_ipc_data_t struct
+ * because this header file is written as a C++ file.
+ */
+typedef union {
+	// Raw data
+	uint8_t raw[BLUENET_IPC_RAM_DATA_ITEM_SIZE];
+	// The data coming from the microapp.
+	bluenet2microapp_ipcdata_t bluenet2microappData;
+} __attribute__((packed, aligned(4))) bluenet_ipc_data_cpp_t;
 
 /**
  * Header for io buffers shared between bluenet and microapp. The payload of the io buffer always starts with this

--- a/source/shared/ipc/cs_IpcRamData.c
+++ b/source/shared/ipc/cs_IpcRamData.c
@@ -16,18 +16,19 @@
 bluenet_ipc_ram_data_t m_bluenet_ipc_ram __attribute__((section(".bluenet_ipc_ram"))) __attribute__((used));
 
 /*
- * A simple additive checksum with inversion of the result to detect
- * all zeros. This is the checksum used in IP headers. The only difference
- * is that here we run it over 8-bit data items rather than 16-bit words.
+ * A simple additive checksum with inversion of the result to detect all zeros. This is the checksum used in IP
+ * headers. The only difference is that here we run it over 8-bit data items rather than 16-bit words.
  */
 uint16_t calculateChecksum(bluenet_ipc_ram_data_item_t* item) {
 	uint16_t sum = 0;
 
-	sum += item->index;
-	sum += item->dataSize;
+	sum += item->header.major;
+	sum += item->header.minor;
+	sum += item->header.index;
+	sum += item->header.dataSize;
 
 	for (uint8_t i = 0; i < BLUENET_IPC_RAM_DATA_ITEM_SIZE; ++i) {
-		sum += item->data[i];
+		sum += item->data.raw[i];
 	}
 	sum = (sum >> 8) + (sum & 0xFF);
 	sum += sum >> 8;
@@ -38,52 +39,99 @@ uint16_t calculateChecksum(bluenet_ipc_ram_data_item_t* item) {
 /*
  * We will do a memcpy with zero padding. This data has to be absolutely valid in all circumstances.
  */
-enum IpcRetCode setRamData(uint8_t index, uint8_t* data, const uint8_t dataSize) {
+enum IpcRetCode setRamData(bluenet_ipc_data_header_t* header, uint8_t* data) {
 	if (data == NULL) {
 		return IPC_RET_NULL_POINTER;
 	}
+	uint8_t index = header->index;
 	if (index > BLUENET_IPC_RAM_DATA_ITEMS) {
 		return IPC_RET_INDEX_OUT_OF_BOUND;
 	}
-	if (dataSize > BLUENET_IPC_RAM_DATA_ITEM_SIZE) {
+	if (header->dataSize > BLUENET_IPC_RAM_DATA_ITEM_SIZE) {
 		return IPC_RET_DATA_TOO_LARGE;
 	}
-	m_bluenet_ipc_ram.item[index].index    = index;
-	m_bluenet_ipc_ram.item[index].dataSize = dataSize;
-
-	memcpy(m_bluenet_ipc_ram.item[index].data, data, dataSize);
-
-	// Zero padding
-	memset(m_bluenet_ipc_ram.item[index].data + dataSize, 0, BLUENET_IPC_RAM_DATA_ITEM_SIZE - dataSize);
-
-	m_bluenet_ipc_ram.item[index].checksum = calculateChecksum(&m_bluenet_ipc_ram.item[index]);
+	// Copy header
+	memcpy(&m_bluenet_ipc_ram.item[index].header, header, sizeof(header));
+	// Copy data
+	memcpy(m_bluenet_ipc_ram.item[index].data.raw, data, header->dataSize);
+	// Zero padding of the data
+	memset(m_bluenet_ipc_ram.item[index].data.raw + header->dataSize,
+		   0,
+		   BLUENET_IPC_RAM_DATA_ITEM_SIZE - header->dataSize);
+	// Calculate the checksum ourselves (if present in header parameter it is ignored)
+	m_bluenet_ipc_ram.item[index].header.checksum = calculateChecksum(&m_bluenet_ipc_ram.item[index]);
 	return IPC_RET_SUCCESS;
 }
 
-enum IpcRetCode getRamData(uint8_t index, uint8_t* buf, uint8_t length, uint8_t* dataSize) {
-	if (buf == NULL) {
+/*
+ * Allow receiving entity to obtain information about the header, such as minor and major to set up code that can be
+ * backwards compatible. It is up to the receiving entity to indicate if the checksum has to be taken into account.
+ *
+ * For example, a reason to bump the major version is when the checksum calculation itself changes. This function will
+ * in that case allow the developer to retrieve the (hopefully uncorrupted) major field and can call getRamData with
+ * another major that it also knows how to parse.
+ */
+enum IpcRetCode getRamDataHeader(bluenet_ipc_data_header_t* header, bool use_checksum) {
+	uint8_t index = header->index;
+	if (header->index > BLUENET_IPC_RAM_DATA_ITEMS) {
+		return IPC_RET_INDEX_OUT_OF_BOUND;
+	}
+	if (use_checksum) {
+		uint16_t checksum = calculateChecksum(&m_bluenet_ipc_ram.item[index]);
+		if (checksum != m_bluenet_ipc_ram.item[index].header.checksum) {
+			return IPC_RET_DATA_INVALID;
+		}
+	}
+	memcpy(header, &m_bluenet_ipc_ram.item[index].header, sizeof(header));
+	return IPC_RET_SUCCESS;
+}
+
+/*
+ * Note that we do not completely trust the data within RAM either...
+ *
+ * From the fields in header, the field index is expected to be written. If major and minor are both 0, they will be
+ * filled with default values.
+ *
+ * If data is corrupted in this section, which can happen in all kinds of ways, from cosmic rays till stack overflows,
+ * this can lead to segfaults. Hence, we are excessively checking stuff here.
+ *
+ * Ram data will not be returned if the header->major and header->minor arguments are lower than what is stored.
+ */
+enum IpcRetCode getRamData(bluenet_ipc_data_header_t* header, uint8_t* data, uint8_t max_length) {
+	if (data == NULL) {
 		return IPC_RET_NULL_POINTER;
 	}
+	uint8_t index = header->index;
 	if (index > BLUENET_IPC_RAM_DATA_ITEMS) {
 		return IPC_RET_INDEX_OUT_OF_BOUND;
 	}
-	if (m_bluenet_ipc_ram.item[index].index != index) {
+	if (header->major == 0 && header->minor == 0) {
+		header->major = BLUENET_IPC_MAJOR_DEFAULT;
+		header->minor = BLUENET_IPC_MINOR_DEFAULT;
+	}
+	if (m_bluenet_ipc_ram.item[index].header.index != index) {
 		return IPC_RET_NOT_FOUND;
 	}
-	if (m_bluenet_ipc_ram.item[index].dataSize > BLUENET_IPC_RAM_DATA_ITEM_SIZE) {
+	if (m_bluenet_ipc_ram.item[index].header.dataSize > BLUENET_IPC_RAM_DATA_ITEM_SIZE) {
 		return IPC_RET_DATA_TOO_LARGE;
 	}
-	if (length < m_bluenet_ipc_ram.item[index].dataSize) {
+	if (max_length < m_bluenet_ipc_ram.item[index].header.dataSize) {
 		return IPC_RET_BUFFER_TOO_SMALL;
+	}
+	if (header->major < m_bluenet_ipc_ram.item[index].header.major) {
+		return IPC_RET_DATA_MAJOR_DIFF;
+	}
+	if (header->minor < m_bluenet_ipc_ram.item[index].header.minor) {
+		return IPC_RET_DATA_MINOR_DIFF;
 	}
 
 	uint16_t checksum = calculateChecksum(&m_bluenet_ipc_ram.item[index]);
-	if (checksum != m_bluenet_ipc_ram.item[index].checksum) {
+	if (checksum != m_bluenet_ipc_ram.item[index].header.checksum) {
 		return IPC_RET_DATA_INVALID;
 	}
 
-	memcpy(buf, m_bluenet_ipc_ram.item[index].data, m_bluenet_ipc_ram.item[index].dataSize);
-	*dataSize = m_bluenet_ipc_ram.item[index].dataSize;
+	memcpy(data, &m_bluenet_ipc_ram.item[index].data, m_bluenet_ipc_ram.item[index].header.dataSize);
+	header->dataSize = m_bluenet_ipc_ram.item[index].header.dataSize;
 	return IPC_RET_SUCCESS;
 }
 

--- a/source/shared/ipc/cs_IpcRamData.h
+++ b/source/shared/ipc/cs_IpcRamData.h
@@ -63,14 +63,16 @@ enum BuildType {
  * that represented the CMAKE_BUILD_TYPE, such as Release or Debug.
  */
 typedef struct {
-	uint8_t protocol;  // Should be 1.
+	// Major version of this struct
+	uint8_t ipcDataMajor;
+	uint8_t ipcDataMinor;
 	uint16_t dfuVersion;
-	uint8_t major;
-	uint8_t minor;
-	uint8_t patch;
+	uint8_t bootloaderMajor;
+	uint8_t bootloaderMinor;
+	uint8_t bootloaderPatch;
 	// A prerelease value. This is 255 for normal releases.
-	uint8_t prerelease;
-	uint8_t buildType;
+	uint8_t bootloaderPrerelease;
+	uint8_t bootloaderBuildType;
 } __attribute__((packed, aligned(4))) bluenet_ipc_bootloader_data_t;
 
 /**

--- a/source/shared/ipc/cs_IpcRamData.h
+++ b/source/shared/ipc/cs_IpcRamData.h
@@ -20,9 +20,11 @@ extern "C" {
 // The size of each slot for interprocess communication
 #define BLUENET_IPC_RAM_DATA_ITEM_SIZE 24
 
-// Default version numbers for major and minor
-#define BLUENET_IPC_MAJOR_DEFAULT 1
-#define BLUENET_IPC_MINOR_DEFAULT 0
+// Version for major for the IPC header itself
+#define BLUENET_IPC_HEADER_MAJOR 1
+
+// Version for minor for the IPC header itself
+#define BLUENET_IPC_HEADER_MINOR 0
 
 enum IpcIndex {
 	IPC_INDEX_RESERVED           = 0,
@@ -122,31 +124,33 @@ typedef struct {
 /**
  * Set data in IPC ram.
  *
- * @param[in] header         Header of which all fields apart from header.checksum and header.reserved are required.
+ * @param[in] index          Index of IPC segment.
+ * @param[in] dataSize       Size of data.
  * @param[in] data           Data pointer.
  * @return                   Error code (success is indicated by 0).
  */
-enum IpcRetCode setRamData(bluenet_ipc_data_header_t* header, uint8_t* data);
+enum IpcRetCode setRamData(uint8_t index, uint8_t dataSize, uint8_t* data);
 
 /**
  * Get data from IPC ram.
  *
- * @param[inout] header      Header of which header.index is required and header.major and minor are optional. The
- *                           field header.dataSize will be written with size of the returned data.
+ * @param[in] index          Index of IPC segment.
  * @param[out] data          Buffer to copy the data to.
- * @param[in] max_length     Size of the buffer to copy the data to (should be large enough).
+ * @param[out] dataSize      Size of data.
+ * @param[in] maxSize        Size of the buffer to copy the data to (should be large enough).
  * @return                   Error code (success is indicated by 0).
  */
-enum IpcRetCode getRamData(bluenet_ipc_data_header_t* header, uint8_t* data, uint8_t max_length);
+enum IpcRetCode getRamData(uint8_t index, uint8_t* data, uint8_t* dataSize, uint8_t maxSize);
 
 /**
  * Get header for specific data. Calculating the checksum can be omitted.
  *
- * @param[in] header         Header of which header.index is required.
- * @param[in] use_checksum   Calculate the checksum.
- * @return                   Error code (success is indicated by 0).
+ * @param[out] header              Get only the header.
+ * @param[in] index                Index of IPC segment.
+ * @param[in] doCalculateChecksum  Calculate the checksum.
+ * @return                         Error code (success is indicated by 0).
  */
-enum IpcRetCode getRamDataHeader(bluenet_ipc_data_header_t* header, bool use_checksum);
+enum IpcRetCode getRamDataHeader(bluenet_ipc_data_header_t* header, uint8_t index, bool doCalculateChecksum);
 
 /**
  * Get the underlying complete data struct. Do not use if not truly necessary. Its implementation might change.

--- a/source/shared/ipc/cs_IpcRamData.h
+++ b/source/shared/ipc/cs_IpcRamData.h
@@ -11,6 +11,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <stdint.h>
 
 // The number of slots for interprocess communication
@@ -18,6 +19,10 @@ extern "C" {
 
 // The size of each slot for interprocess communication
 #define BLUENET_IPC_RAM_DATA_ITEM_SIZE 24
+
+// Default version numbers for major and minor
+#define BLUENET_IPC_MAJOR_DEFAULT 1
+#define BLUENET_IPC_MINOR_DEFAULT 0
 
 enum IpcIndex {
 	IPC_INDEX_RESERVED           = 0,
@@ -34,6 +39,8 @@ enum IpcRetCode {
 	IPC_RET_NOT_FOUND          = 4,
 	IPC_RET_NULL_POINTER       = 5,
 	IPC_RET_DATA_INVALID       = 6,
+	IPC_RET_DATA_MAJOR_DIFF    = 7,
+	IPC_RET_DATA_MINOR_DIFF    = 8,
 };
 
 enum BuildType {
@@ -55,27 +62,54 @@ enum BuildType {
  */
 typedef struct {
 	uint8_t protocol;  // Should be 1.
-	uint16_t dfu_version;
+	uint16_t dfuVersion;
 	uint8_t major;
 	uint8_t minor;
 	uint8_t patch;
-	uint8_t prerelease;  // 255 means it's not a pre-release.
-	uint8_t build_type;  // See BuildType.
+	// A prerelease value. This is 255 for normal releases.
+	uint8_t prerelease;
+	uint8_t buildType;
 } __attribute__((packed, aligned(4))) bluenet_ipc_bootloader_data_t;
 
 /**
- * One item of data in the IPC ram.
- * The data array is word aligned.
+ * Make data available as union.
+ */
+typedef union {
+	// Raw data
+	uint8_t raw[BLUENET_IPC_RAM_DATA_ITEM_SIZE];
+	// The data coming from the bootloader
+	bluenet_ipc_bootloader_data_t bootloaderData;
+} __attribute__((packed, aligned(4))) bluenet_ipc_data_t;
+
+/**
+ * The header of a data item in IPC ram.
  *
- * index      The index of this item, to see if this item has been set.
- * dataSize   How many bytes of useful data is in the data array.
- * checksum   Checksum calculated over the index, data size, and _complete_ data array.
+ * Bump the major version if there's a change that is not backwards-compatible. Bump the minor version if there's a
+ * change that is backwards-compatible, for example the addition of a field within the data object.
  */
 typedef struct {
+	// The major version.
+	uint8_t major;
+	// The minor version.
+	uint8_t minor;
+	// The index of this item, to see if this item has been set.
 	uint8_t index;
+	// How many bytes are informational within the data array.
 	uint8_t dataSize;
+	// Checksum calculated over the data array, but also all fields above.
 	uint16_t checksum;
-	uint8_t data[BLUENET_IPC_RAM_DATA_ITEM_SIZE];
+	// Reserve some bytes to be word aligned.
+	uint8_t reserved[2];
+} __attribute__((packed, aligned(4))) bluenet_ipc_data_header_t;
+
+/**
+ * One item of data in the IPC ram. The data is word-aligned.
+ */
+typedef struct {
+	// The header
+	bluenet_ipc_data_header_t header;
+	// The data array
+	bluenet_ipc_data_t data;
 } __attribute__((packed, aligned(4))) bluenet_ipc_ram_data_item_t;
 
 /**
@@ -88,21 +122,31 @@ typedef struct {
 /**
  * Set data in IPC ram.
  *
- * @param[in] index          Index of item.
+ * @param[in] header         Header of which all fields apart from header.checksum and header.reserved are required.
  * @param[in] data           Data pointer.
- * @param[in] dataSize       Size of the data.
+ * @return                   Error code (success is indicated by 0).
  */
-enum IpcRetCode setRamData(uint8_t index, uint8_t* data, const uint8_t dataSize);
+enum IpcRetCode setRamData(bluenet_ipc_data_header_t* header, uint8_t* data);
 
 /**
  * Get data from IPC ram.
  *
- * @param[in] index          Index of item.
- * @param[out] buf           Buffer to copy the data to.
- * @param[in] length         Size of the buffer.
- * @param[out] dataSize      Size of the data.
+ * @param[inout] header      Header of which header.index is required and header.major and minor are optional. The
+ *                           field header.dataSize will be written with size of the returned data.
+ * @param[out] data          Buffer to copy the data to.
+ * @param[in] max_length     Size of the buffer to copy the data to (should be large enough).
+ * @return                   Error code (success is indicated by 0).
  */
-enum IpcRetCode getRamData(uint8_t index, uint8_t* buf, uint8_t length, uint8_t* dataSize);
+enum IpcRetCode getRamData(bluenet_ipc_data_header_t* header, uint8_t* data, uint8_t max_length);
+
+/**
+ * Get header for specific data. Calculating the checksum can be omitted.
+ *
+ * @param[in] header         Header of which header.index is required.
+ * @param[in] use_checksum   Calculate the checksum.
+ * @return                   Error code (success is indicated by 0).
+ */
+enum IpcRetCode getRamDataHeader(bluenet_ipc_data_header_t* header, bool use_checksum);
 
 /**
  * Get the underlying complete data struct. Do not use if not truly necessary. Its implementation might change.

--- a/source/src/cfg/cs_AutoConfig.cpp.in
+++ b/source/src/cfg/cs_AutoConfig.cpp.in
@@ -98,3 +98,8 @@ const int8_t g_LED1_INDEX                 = ${LED1_INDEX};
 const int8_t g_LED2_INDEX                 = ${LED2_INDEX};
 const int8_t g_LED3_INDEX                 = ${LED3_INDEX};
 const int8_t g_LED4_INDEX                 = ${LED4_INDEX};
+
+const uint8_t g_BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MAJOR = ${BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MAJOR};
+const uint8_t g_BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MINOR = ${BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MINOR};
+
+

--- a/source/src/cs_Crownstone.cpp
+++ b/source/src/cs_Crownstone.cpp
@@ -913,19 +913,26 @@ void printBootloaderInfo() {
 		LOGw("Bootloader IPC data error = %i", retCode);
 		return;
 	}
+	if (ipcData.bootloaderData.ipcDataMajor != g_BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MAJOR) {
+		LOGi("Different major. Not known how to parse bootloader IPC data.");
+		return;
+	}
+	if (ipcData.bootloaderData.ipcDataMinor > g_BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MINOR) {
+		LOGi("New minor. Will parse only part of bootloader IPC data");
+		return;
+	}
 	if (dataSize != sizeof(ipcData.bootloaderData)) {
 		LOGw("Bootloader IPC data struct has the incorrect size");
 		return;
 	}
-	LOGd("Bootloader version protocol=%u dfuVersion=%u buildType=%u",
-		 ipcData.bootloaderData.protocol,
-		 ipcData.bootloaderData.dfuVersion,
-		 ipcData.bootloaderData.buildType);
 	LOGi("Bootloader version: %u.%u.%u-RC%u",
-		 ipcData.bootloaderData.major,
-		 ipcData.bootloaderData.minor,
-		 ipcData.bootloaderData.patch,
-		 ipcData.bootloaderData.prerelease);
+		 ipcData.bootloaderData.bootloaderMajor,
+		 ipcData.bootloaderData.bootloaderMinor,
+		 ipcData.bootloaderData.bootloaderPatch,
+		 ipcData.bootloaderData.bootloaderPrerelease);
+	LOGd("Bootloader dfuVersion=%u buildType=%u",
+		 ipcData.bootloaderData.dfuVersion,
+		 ipcData.bootloaderData.bootloaderBuildType);
 }
 
 /**********************************************************************************************************************

--- a/source/src/cs_Crownstone.cpp
+++ b/source/src/cs_Crownstone.cpp
@@ -907,18 +907,17 @@ void Crownstone::printLoadStats() {
 
 void printBootloaderInfo() {
 	bluenet_ipc_data_t ipcData;
-	bluenet_ipc_data_header_t header;
-	header.index = IPC_INDEX_BOOTLOADER_VERSION;
-	int retCode  = getRamData(&header, ipcData.raw, sizeof(ipcData.raw));
+	uint8_t dataSize;
+	int retCode = getRamData(IPC_INDEX_BOOTLOADER_VERSION, ipcData.raw, &dataSize, sizeof(ipcData.raw));
 	if (retCode != IPC_RET_SUCCESS) {
-		LOGw("No IPC data found, error = %i", retCode);
+		LOGw("Bootloader IPC data error = %i", retCode);
 		return;
 	}
-	if (header.dataSize != sizeof(ipcData.bootloaderData)) {
-		LOGw("IPC data struct has the incorrect size");
+	if (dataSize != sizeof(ipcData.bootloaderData)) {
+		LOGw("Bootloader IPC data struct has the incorrect size");
 		return;
 	}
-	LOGd("Bootloader version protocol=%u dfu_version=%u build_type=%u",
+	LOGd("Bootloader version protocol=%u dfuVersion=%u buildType=%u",
 		 ipcData.bootloaderData.protocol,
 		 ipcData.bootloaderData.dfuVersion,
 		 ipcData.bootloaderData.buildType);

--- a/source/src/microapp/cs_Microapp.cpp
+++ b/source/src/microapp/cs_Microapp.cpp
@@ -242,7 +242,7 @@ cs_ret_code_t Microapp::handleGetInfo(cs_result_t& result) {
 		return ERR_BUFFER_TOO_SMALL;
 	}
 
-	// info->protocol           = MICROAPP_PROTOCOL;
+	info->protocol           = MICROAPP_CONTROL_COMMAND_PROTOCOL;
 	info->maxApps            = MAX_MICROAPPS;
 	info->maxAppSize         = MICROAPP_MAX_SIZE;
 	info->maxChunkSize       = MICROAPP_UPLOAD_MAX_CHUNK_SIZE;
@@ -378,7 +378,7 @@ cs_ret_code_t Microapp::handleDisable(microapp_ctrl_header_t* packet) {
 
 cs_ret_code_t Microapp::checkHeader(microapp_ctrl_header_t* packet) {
 	LOGMicroappInfo("checkHeader %u", packet->index);
-	if (packet->protocol != MICROAPP_DATA_PROTOCOL) {
+	if (packet->protocol != MICROAPP_CONTROL_COMMAND_PROTOCOL) {
 		LOGw("Unsupported protocol: %u", packet->protocol);
 		return ERR_PROTOCOL_UNSUPPORTED;
 	}

--- a/source/src/microapp/cs_Microapp.cpp
+++ b/source/src/microapp/cs_Microapp.cpp
@@ -146,7 +146,11 @@ cs_ret_code_t Microapp::enableApp(uint8_t index) {
 	MicroappStorage& storage = MicroappStorage::getInstance();
 	storage.getAppHeader(index, header);
 	if (header.sdkVersionMajor != MICROAPP_SDK_MAJOR || header.sdkVersionMinor > MICROAPP_SDK_MINOR) {
-		LOGw("Microapp sdk version %u.%u is not supported", header.sdkVersionMajor, header.sdkVersionMinor);
+		LOGw("Microapp sdk version %u.%u is not supported (it is >%u.%u)",
+			 header.sdkVersionMajor,
+			 header.sdkVersionMinor,
+			 MICROAPP_SDK_MAJOR,
+			 MICROAPP_SDK_MINOR);
 		return ERR_PROTOCOL_UNSUPPORTED;
 	}
 
@@ -238,7 +242,7 @@ cs_ret_code_t Microapp::handleGetInfo(cs_result_t& result) {
 		return ERR_BUFFER_TOO_SMALL;
 	}
 
-	info->protocol           = MICROAPP_PROTOCOL;
+	// info->protocol           = MICROAPP_PROTOCOL;
 	info->maxApps            = MAX_MICROAPPS;
 	info->maxAppSize         = MICROAPP_MAX_SIZE;
 	info->maxChunkSize       = MICROAPP_UPLOAD_MAX_CHUNK_SIZE;
@@ -373,7 +377,8 @@ cs_ret_code_t Microapp::handleDisable(microapp_ctrl_header_t* packet) {
 }
 
 cs_ret_code_t Microapp::checkHeader(microapp_ctrl_header_t* packet) {
-	if (packet->protocol != MICROAPP_PROTOCOL) {
+	LOGMicroappInfo("checkHeader %u", packet->index);
+	if (packet->protocol != MICROAPP_DATA_PROTOCOL) {
 		LOGw("Unsupported protocol: %u", packet->protocol);
 		return ERR_PROTOCOL_UNSUPPORTED;
 	}

--- a/source/src/microapp/cs_MicroappController.cpp
+++ b/source/src/microapp/cs_MicroappController.cpp
@@ -106,9 +106,8 @@ void microappCallbackDummy() {
 		io_buffers.microapp2bluenet.payload[0] = CS_MICROAPP_SDK_TYPE_YIELD;
 		// Get the ram data of ourselves (IPC_INDEX_CROWNSTONE_APP).
 		bluenet2microapp_ipcdata_t ipc_data;
-		bluenet_ipc_data_header_t header;
-		header.index = IPC_INDEX_CROWNSTONE_APP;
-		getRamData(&header, (uint8_t*)&ipc_data, sizeof(bluenet2microapp_ipcdata_t));
+		uint8_t dataSize;
+		getRamData(IPC_INDEX_CROWNSTONE_APP, (uint8_t*)&ipc_data, &dataSize, sizeof(bluenet2microapp_ipcdata_t));
 
 		// Perform the actual callback. Should call microappCallback and yield.
 		ipc_data.microappCallback(CS_MICROAPP_CALLBACK_UPDATE_IO_BUFFER, &io_buffers);
@@ -190,12 +189,7 @@ void MicroappController::setIpcRam() {
 
 	LOGi("Set callback to %p", ipcData.bluenet2microappData.microappCallback);
 
-	bluenet_ipc_data_header_t header;
-	header.index     = IPC_INDEX_CROWNSTONE_APP;
-	header.major     = MICROAPP_IPC_CURRENT_PROTOCOL_MAJOR;
-	header.minor     = MICROAPP_IPC_CURRENT_PROTOCOL_MINOR;
-	header.dataSize  = sizeof(bluenet2microapp_ipcdata_t);
-	uint32_t retCode = setRamData(&header, ipcData.raw);
+	uint32_t retCode = setRamData(IPC_INDEX_CROWNSTONE_APP, sizeof(bluenet2microapp_ipcdata_t), ipcData.raw);
 	if (retCode != ERR_SUCCESS) {
 		LOGw("Microapp IPC RAM data error, retCode=%u", retCode);
 		return;

--- a/source/src/microapp/cs_MicroappController.cpp
+++ b/source/src/microapp/cs_MicroappController.cpp
@@ -185,7 +185,7 @@ void MicroappController::setIpcRam() {
 	LOGi("Set IPC info for microapp");
 	bluenet_ipc_data_cpp_t ipcData;
 	ipcData.bluenet2microappData.microappCallback = microappCallback;
-	ipcData.bluenet2microappData.protocol         = MICROAPP_DATA_PROTOCOL;
+	ipcData.bluenet2microappData.dataProtocol     = MICROAPP_IPC_DATA_PROTOCOL;
 
 	LOGi("Set callback to %p", ipcData.bluenet2microappData.microappCallback);
 

--- a/source/src/processing/cs_CommandHandler.cpp
+++ b/source/src/processing/cs_CommandHandler.cpp
@@ -270,15 +270,14 @@ void CommandHandler::handleCmdGetBootloaderVersion(
 		cs_data_t commandData, const EncryptionAccessLevel accessLevel, cs_result_t& result) {
 	LOGi(STR_HANDLE_COMMAND "get bootloader version");
 
-	bluenet_ipc_data_header_t header;
-	header.index = IPC_INDEX_BOOTLOADER_VERSION;
-	int retCode  = getRamData(&header, result.buf.data, result.buf.len);
+	uint8_t dataSize;
+	int retCode = getRamData(IPC_INDEX_BOOTLOADER_VERSION, result.buf.data, &dataSize, result.buf.len);
 	if (retCode != IPC_RET_SUCCESS) {
 		LOGw("IPC error = %i", retCode);
 		result.returnCode = ERR_NOT_FOUND;
 		return;
 	}
-	result.dataSize   = header.dataSize;
+	result.dataSize   = dataSize;
 	result.returnCode = ERR_SUCCESS;
 	return;
 }

--- a/source/src/processing/cs_CommandHandler.cpp
+++ b/source/src/processing/cs_CommandHandler.cpp
@@ -270,14 +270,15 @@ void CommandHandler::handleCmdGetBootloaderVersion(
 		cs_data_t commandData, const EncryptionAccessLevel accessLevel, cs_result_t& result) {
 	LOGi(STR_HANDLE_COMMAND "get bootloader version");
 
-	uint8_t dataSize;
-	int retCode = getRamData(IPC_INDEX_BOOTLOADER_VERSION, result.buf.data, result.buf.len, &dataSize);
+	bluenet_ipc_data_header_t header;
+	header.index = IPC_INDEX_BOOTLOADER_VERSION;
+	int retCode  = getRamData(&header, result.buf.data, result.buf.len);
 	if (retCode != IPC_RET_SUCCESS) {
-		LOGw("No IPC data found, error = %i", retCode);
+		LOGw("IPC error = %i", retCode);
 		result.returnCode = ERR_NOT_FOUND;
 		return;
 	}
-	result.dataSize   = dataSize;
+	result.dataSize   = header.dataSize;
 	result.returnCode = ERR_SUCCESS;
 	return;
 }

--- a/source/src/processing/cs_CommandHandler.cpp
+++ b/source/src/processing/cs_CommandHandler.cpp
@@ -277,6 +277,19 @@ void CommandHandler::handleCmdGetBootloaderVersion(
 		result.returnCode = ERR_NOT_FOUND;
 		return;
 	}
+	bluenet_ipc_bootloader_data_t* bootloaderData = (bluenet_ipc_bootloader_data_t*)result.buf.data;
+	if (bootloaderData->ipcDataMajor != g_BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MAJOR) {
+		LOGi("Different major. Not known how to parse bootloader IPC data.");
+		return;
+	}
+	if (bootloaderData->ipcDataMinor > g_BLUENET_COMPAT_BOOTLOADER_IPC_RAM_MINOR) {
+		LOGi("New minor. Will parse only part of bootloader IPC data");
+		return;
+	}
+	if (dataSize != sizeof(*bootloaderData)) {
+		// We will go through though, assuming the mismatch comes from a minor increase
+		LOGw("Bootloader IPC data struct has the incorrect size");
+	}
 	result.dataSize   = dataSize;
 	result.returnCode = ERR_SUCCESS;
 	return;


### PR DESCRIPTION
+ This needs to be properly documented as well.
+ There is a version required for the IPC structs. When those structs,
  e.g. between bootloader and bluenet firmware, the corresponding
  functions need to be able to implement backwards compatibility. The
  implement version is a major/minor combination.
+ Bluenet and a microapp also communicates over IPC. In this struct a
  callback can be written by bluenet to be called by the microapp. If
  this struct changes, a major/minor update make sense.
+ The messages between bluenet and microapps are communicated back and
  forth by a separate buffer (maintained by the microapp so it doesn't
  incur penalties at the bluenet side if no microapp is present). This
  is according to a versioned protocol. This protocol version is also
  present in the IPC struct [1].
+ The major/minor with respect to the SDK is not clearly separated from
  the protocol version that is used for uploading microapps [2].

[1] It is perhaps sufficient to have just a minor update for a protocol
update?
[2] Naming must be so that it is very clear what is done where. The
reason to have a protocol version for uploading microapps is to allow
for different upload mechanisms without having to bump the general BLE
protocol version. Updating the general BLE protocol version is very
invasive.