### PR TITLE
More microapp safety checks.

### DIFF
--- a/source/include/microapp/cs_Microapp.h
+++ b/source/include/microapp/cs_Microapp.h
@@ -31,6 +31,16 @@ public:
 	 */
 	void init(OperationMode operationMode);
 
+	/**
+	 * Checks app state and returns true if this app is allowed to run.
+	 */
+	bool canRunApp(uint8_t index);
+
+	/**
+	 * To be called when a microapp took too long to yield.
+	 */
+	void onExcessiveCallDuration(uint8_t appIndex);
+
 private:
 	/**
 	 * Singleton, constructor, also copy constructor, is private.
@@ -43,6 +53,11 @@ private:
 	 * The state of each microapp.
 	 */
 	microapp_state_t _states[g_MICROAPP_COUNT];
+
+	/**
+	 * Keep up whether the microapp has been started yet.
+	 */
+	bool _started[g_MICROAPP_COUNT];
 
 	/**
 	 * Local flag to indicate that ram section has been loaded.
@@ -103,11 +118,6 @@ private:
 	 * Store app state to flash.
 	 */
 	cs_ret_code_t storeState(uint8_t index);
-
-	/**
-	 * Checks app state and returns true if this app is allowed to run.
-	 */
-	bool canRunApp(uint8_t index);
 
 	/**
 	 * To be called every tick.

--- a/source/include/microapp/cs_MicroappController.h
+++ b/source/include/microapp/cs_MicroappController.h
@@ -110,6 +110,13 @@ private:
 	static const uint8_t MICROAPP_MAX_BLUENET_EVENT_INTERRUPT_REGISTRATIONS = 10;
 
 	/**
+	 * The maximum time in ms a call to a microapp can take.
+	 *
+	 * Take into account that real interrupts are included in this time.
+	 */
+	static const uint32_t MICROAPP_MAX_CALL_DURATION_MS                     = 20;
+
+	/**
 	 * Buffer for keeping track of registered interrupts
 	 */
 	microapp_soft_interrupt_registration_t _softInterruptRegistrations[MICROAPP_MAX_SOFT_INTERRUPT_REGISTRATIONS];
@@ -245,6 +252,14 @@ public:
 	 * Checks whether the microapp has empty interrupt slots to deal with a new softInterrupt
 	 */
 	bool allowSoftInterrupts(MicroappSdkType type, uint8_t id);
+
+	/**
+	 * Checks whether the CPU is busy.
+	 * This is done by checking if:
+	 * - The scheduler is almost full.
+	 * - ADC buffers have been skipped.
+	 */
+	bool isCpuBusy();
 
 	/**
 	 * Register interrupts for bluenet events.

--- a/source/include/processing/cs_PowerSampling.h
+++ b/source/include/processing/cs_PowerSampling.h
@@ -60,6 +60,13 @@ public:
 	 */
 	void enableZeroCrossingInterrupt(ps_zero_crossing_cb_t callback);
 
+	/**
+	 * Get the number of bufs that have been recently skipped.
+	 *
+	 * Is reset every second.
+	 */
+	uint32_t getSkippedBufCount();
+
 	/** handle (crownstone) events
 	 */
 	void handleEvent(event_t& event);
@@ -206,6 +213,9 @@ private:
 
 	cs_adc_restarts_t _adcRestarts;
 	cs_adc_channel_swaps_t _adcChannelSwaps;
+
+	//! Count number of buffers that have been skipped for processing.
+	uint32_t _bufSkipCount = 0;
 
 	/**
 	 * Load energy used from IPC ram.

--- a/source/include/protocol/cs_MicroappPackets.h
+++ b/source/include/protocol/cs_MicroappPackets.h
@@ -120,8 +120,10 @@ struct __attribute__((packed)) microapp_state_t {
 	uint8_t memoryUsage : 1;
 	// Did reboot
 	uint8_t didReboot : 1;
+	// Whether a call to the microapp took too long to yield.
+	bool exceededCallDuration : 1;
 	// Reserved, must be 0 for now.
-	uint16_t reservedTest : 8;
+	uint16_t reservedTest : 7;
 	// Index of registered function that didn't pass yet, and that we are calling now. MICROAPP_FUNCTION_NONE for none.
 	uint8_t tryingFunction = MICROAPP_FUNCTION_NONE;
 	// Index of registered function that was tried, but didn't pass. MICROAPP_FUNCTION_NONE for none.


### PR DESCRIPTION
Check CPU usage before calling the microapp.
Disable microapp when a call took too long to yield.
Fixed disabling of microapps.